### PR TITLE
Refactor job titles and topics for clarity and accuracy

### DIFF
--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -354,7 +354,7 @@ export const jobs = [
     company: "The Hartford",
     logo: "the-hartford.svg",
     url: "https://www.thehartford.com/",
-    title: "Multi-Stack Engineer - Reliability Engineering",
+    title: "Multi-Stack Engineer — Reliability Engineering",
     summary:
       "Owned application platforms and production operations, focusing on reliability, modernization, and DevOps enablement across the application portfolio.",
     bullets: [
@@ -374,7 +374,7 @@ export const jobs = [
     company: "The Hartford",
     logo: "the-hartford.svg",
     url: "https://www.thehartford.com/",
-    title: "Developer - Personal Lines Insurance",
+    title: "Developer — Production Support",
     summary:
       "Drove delivery and production stability for an internal policy quoting and issuance application, supporting Personal Insurance agents.",
     bullets: [

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -354,7 +354,7 @@ export const jobs = [
     company: "The Hartford",
     logo: "the-hartford.svg",
     url: "https://www.thehartford.com/",
-    title: "Multi-Stack Engineer",
+    title: "Multi-Stack Engineer - Reliability Engineering",
     summary:
       "Owned application platforms and production operations, focusing on reliability, modernization, and DevOps enablement across the application portfolio.",
     bullets: [
@@ -367,14 +367,14 @@ export const jobs = [
     ],
     startDate: "2017",
     endDate: "2018",
-    topic: "Full-Stack / Operations",
+    topic: "Reliability Engineering",
     location: "The Hartford",
   },
   {
     company: "The Hartford",
     logo: "the-hartford.svg",
     url: "https://www.thehartford.com/",
-    title: "Developer",
+    title: "Developer - Personal Lines Insurance",
     summary:
       "Drove delivery and production stability for an internal policy quoting and issuance application, supporting Personal Insurance agents.",
     bullets: [


### PR DESCRIPTION
This pull request makes minor updates to the job history data in `utils/constants.tsx`, clarifying job titles and topics for roles at The Hartford.

- Job titles and topics updated for clarity:
  * Changed the title from "Multi-Stack Engineer" to "Multi-Stack Engineer - Reliability Engineering" and updated the topic from "Full-Stack / Operations" to "Reliability Engineering" for one position. [[1]](diffhunk://#diff-d01376ffc6b70925fed81daa8f355304ae72969f3923a6227017572c1b24f6f2L357-R357) [[2]](diffhunk://#diff-d01376ffc6b70925fed81daa8f355304ae72969f3923a6227017572c1b24f6f2L370-R377)
  * Changed the title from "Developer" to "Developer - Personal Lines Insurance" for another position.