### PR TITLE
Update summary for Senior Staff Software Engineer

### DIFF
--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -284,7 +284,7 @@ export const jobs = [
     url: "https://www.thehartford.com/",
     title: "Senior Staff Software Engineer — Enterprise Platform Engineering",
     summary:
-      "Owner of the enterprise developer platform ecosystem, spanning CI/CD, security, artifact management, and observability across thousands of repositories.",
+      "Leading the enterprise developer platform ecosystem, spanning CI/CD, security, artifact management, and observability across thousands of repositories.",
     bullets: [
       "Drove enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud (**11,000+ repositories**)",
       "Built and operated scalable CI/CD execution, governance, and observability platforms",


### PR DESCRIPTION
This pull request makes a minor wording change to the job summary for the "Senior Staff Software Engineer — Enterprise Platform Engineering" position in the `jobs` array. The update clarifies the role by changing "Owner of" to "Leading" in the summary.