### PR TITLE
Update resume link to new URL

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,6 @@ export default function Home() {
                 </a>
                 <a
                   href="https://resume.brignano.io"
-                  rel="noopener noreferrer"
                   className="inline-flex items-center px-6 py-3 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"
                   onClick={() => {
                     event("CTA Clicked", { type: "Resume" });
@@ -79,7 +78,7 @@ export default function Home() {
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                     />
                   </svg>
                 </a>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
                   </svg>
                 </a>
                 <a
-                  href="https://docs.google.com/document/d/1NIwgN8u-V-1foCZ2Cb5I2KjpnA6birGL0aV9ZDjX5RI/edit?usp=sharing"
+                  href="https://resume.brignano.io"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center px-6 py-3 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -62,7 +62,6 @@ export default function Home() {
                 </a>
                 <a
                   href="https://resume.brignano.io"
-                  target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center px-6 py-3 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"
                   onClick={() => {


### PR DESCRIPTION
This pull request makes a small change to the external link in the `Home` page. The "Resume" button now points to `https://resume.brignano.io` instead of a Google Docs URL.