### PR TITLE
Delete .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: gregrickaby


### PR DESCRIPTION
This pull request makes a minor update by removing the GitHub sponsor username from the `.github/FUNDING.yml` file. No other changes are included.