### PR TITLE
Refine resume: update skills, certifications, and project descriptions

### DIFF
--- a/public/resume.json
+++ b/public/resume.json
@@ -115,7 +115,7 @@
     },
     {
       "category": "CI/CD & DevOps",
-      "items": ["GitHub Actions", "Jenkins", "Harness", "GitLab CI", "CircleCI", "ArgoCD"]
+      "items": ["GitHub Actions", "Jenkins", "Harness", "uDeploy"]
     },
     {
       "category": "Programming Languages",
@@ -127,23 +127,18 @@
     },
     {
       "category": "Observability",
-      "items": ["Dynatrace", "Splunk", "Datadog", "Prometheus", "Grafana", "ELK Stack"]
+      "items": ["Dynatrace", "Splunk", "Google Analytics"]
     },
     {
       "category": "Frameworks & Tools",
-      "items": ["Next.js", "React", "Spring Boot", "Node.js", "FastAPI", "Express"]
+      "items": ["Next.js", "React", "Spring Boot", "Node.js", "Express"]
     }
   ],
   "certifications": [
     {
-      "name": "AWS Certified Solutions Architect",
-      "issuer": "Amazon Web Services",
-      "date": "2022"
-    },
-    {
-      "name": "Certified Kubernetes Administrator (CKA)",
-      "issuer": "Cloud Native Computing Foundation",
-      "date": "2021"
+      "name": "Professional Scrum Developer (PSD)",
+      "issuer": "Scrum.org",
+      "date": "2019"
     }
   ],
   "projects": [
@@ -155,14 +150,9 @@
       "github": "https://github.com/brignano/brignano.io"
     },
     {
-      "name": "Enterprise CI/CD Platform",
-      "description": "Built and maintained enterprise-scale CI/CD platform supporting 11,000+ repositories with governance, security scanning, and observability.",
+      "name": "GitHub Enterprise Cloud Migration",
+      "description": "Architected and executed enterprise-scale CI/CD migration supporting 11,000+ repositories with governance, security scanning, and observability.",
       "technologies": ["GitHub Actions", "Terraform", "AWS", "Python", "TypeScript"]
-    },
-    {
-      "name": "Test Data Management Platform",
-      "description": "Developed enterprise test data management solution enabling scalable, compliant test data provisioning across multiple environments.",
-      "technologies": ["Python", "PostgreSQL", "Docker", "FastAPI", "React"]
     }
   ]
 }


### PR DESCRIPTION
This pull request updates the `public/resume.json` file to reflect changes in skills, certifications, and project experience. The most notable changes include updating technology stacks, revising certifications, and modifying project descriptions to better align with current experience and expertise.

**Skills and Technology Updates:**

* Replaced `GitLab CI`, `CircleCI`, and `ArgoCD` with `uDeploy` in the "CI/CD & DevOps" category.
* Streamlined the "Observability" category to only include `Dynatrace`, `Splunk`, and `Google Analytics`, removing `Datadog`, `Prometheus`, `Grafana`, and `ELK Stack`.
* Removed `FastAPI` from the "Frameworks & Tools" category.

**Certifications:**

* Replaced AWS and Kubernetes certifications with the "Professional Scrum Developer (PSD)" certification from Scrum.org, dated 2019.

**Projects:**

* Updated the "Enterprise CI/CD Platform" project to "GitHub Enterprise Cloud Migration" with a revised description emphasizing migration and architecture.
* Removed the "Test Data Management Platform" project entry.