### PR TITLE
Refactor event tracking to use snake_case format

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
                   href="mailto:hi@brignano.io"
                   className="inline-flex items-center px-6 py-3 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"
                   onClick={() => {
-                    event("CTA Clicked", { type: "Contact" });
+                    event("cta_clicked", { cta: "contact", location: "hero", transport_type: "beacon" });
                   }}
                 >
                   Contact Me
@@ -61,7 +61,7 @@ export default function Home() {
                   href="/resume"
                   className="inline-flex items-center px-6 py-3 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"
                   onClick={() => {
-                    event("CTA Clicked", { type: "Resume" });
+                    event("cta_clicked", { cta: "resume", location: "hero", transport_type: "beacon" });
                   }}
                 >
                   My Resume
@@ -92,10 +92,8 @@ export default function Home() {
                           target="_blank"
                           className="flex items-center border-b dark:border-b-zinc-800 border-zinc-200 group"
                           onClick={() => {
-                            event("Social Link Clicked", {
-                              name: link.name,
-                              href: link.href,
-                            });
+                            const ctaName = String(link.name).toLowerCase().replace(/\s+/g, "_");
+                            event("social_link_clicked", { cta: ctaName, href: link.href, transport_type: "beacon" });
                           }}
                         >
                           {link.icon} <span className="ml-1">{link.name}</span>
@@ -370,7 +368,7 @@ export default function Home() {
                       title={`View graph for the year ${year}`}
                       onClick={() => {
                         setCalendarYear(year);
-                        event("Contribution Graph Year Changed", { year });
+                        event("contribution_graph_year_changed", { year });
                       }}
                     >
                       {year}
@@ -404,7 +402,7 @@ export default function Home() {
               href="mailto:hi@brignano.io"
               className="inline-flex items-center px-8 py-4 border-2 dark:border-zinc-600 border-zinc-400 dark:hover:border-zinc-500 hover:border-zinc-500 dark:text-zinc-300 text-zinc-700 font-bold text-lg rounded-lg transition-all duration-200"
               onClick={() => {
-                event("Contact CTA Clicked", { location: "bottom" });
+                event("cta_clicked", { cta: "contact_bottom", location: "bottom", transport_type: "beacon" });
               }}
             >
               <svg
@@ -428,7 +426,7 @@ export default function Home() {
               rel="noopener noreferrer"
               className="inline-flex items-center px-8 py-4 border-2 dark:border-zinc-600 border-zinc-400 dark:hover:border-zinc-500 hover:border-zinc-500 dark:text-zinc-300 text-zinc-700 font-bold text-lg rounded-lg transition-all duration-200"
               onClick={() => {
-                event("LinkedIn CTA Clicked", { location: "bottom" });
+                event("cta_clicked", { cta: "linkedin_bottom", location: "bottom", transport_type: "beacon" });
               }}
             >
               <svg

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import AOS from "aos";
 import type { ResumeData } from "@/types/resume";
+import { event } from "@/lib/gtag";
 
 export default function Home() {
   const [resumeData, setResumeData] = useState<ResumeData | null>(null);
@@ -125,6 +126,9 @@ export default function Home() {
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center px-4 py-2 border-2 dark:border-zinc-700 border-zinc-300 dark:hover:border-zinc-500 hover:border-zinc-400 font-semibold rounded-lg transition-all duration-200"
+              onClick={() => {
+                event("website_clicked", { cta: "resume_website", origin: "resume", transport_type: "beacon" });
+              }}
             >
               Website
             </a>


### PR DESCRIPTION
This pull request updates event tracking throughout the `Home` and `Resume` pages to standardize event names, add more detailed metadata, and ensure all CTA and social link interactions are consistently tracked. The changes improve analytics granularity and make tracking more uniform across the app.

**Event tracking standardization and improvements:**

* Updated all CTA click handlers in `app/page.tsx` to use standardized event names (`cta_clicked`), include additional metadata (`cta`, `location`, and `transport_type`), and ensure consistent tracking for contact, resume, and LinkedIn buttons. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L42-R42) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L64-R64) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L407-R405) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L431-R429)
* Refactored social link click events to use a normalized event name (`social_link_clicked`) and standardized payload structure, including a normalized CTA name and transport type.
* Updated contribution graph year change tracking to use a standardized event name (`contribution_graph_year_changed`).

**Resume page analytics:**

* Imported the `event` function from `@/lib/gtag` in `app/resume/page.tsx` to enable analytics tracking on the resume page.
* Added tracking for website link clicks on the resume page using a new event name (`website_clicked`) and detailed metadata.