### PR TITLE
Add latest public commit display and AOS initialization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,6 +34,7 @@ This is a personal portfolio website built with Next.js 16, React 19, and Tailwi
 - Use explicit typing where it improves clarity
 - Use `@/` import alias for absolute imports (e.g., `@/components/header`)
 - Follow React 19 conventions (e.g., `React.ReactNode` for children)
+ - Prefer optional chaining (`obj?.prop`) and nullish coalescing (`??`) when appropriate to reduce nested conditional checks and simplify runtime-safe property access.
 
 ### React Components
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,7 @@ This is a personal portfolio website built with Next.js 16, React 19, and Tailwi
 - Use explicit typing where it improves clarity
 - Use `@/` import alias for absolute imports (e.g., `@/components/header`)
 - Follow React 19 conventions (e.g., `React.ReactNode` for children)
- - Prefer optional chaining (`obj?.prop`) and nullish coalescing (`??`) when appropriate to reduce nested conditional checks and simplify runtime-safe property access.
+- Prefer optional chaining (`obj?.prop`) and nullish coalescing (`??`) when appropriate to reduce nested conditional checks and simplify runtime-safe property access.
 
 ### React Components
 

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -380,18 +380,14 @@ export default async function Page() {
                       {typeof latestCommit.filesChanged === "number" && (
                         <>
                           <span className="mx-1 md:mx-2">&nbsp;•</span>
-                          <span>
-                            {latestCommit.filesChanged} files changed
-                          </span>
+                          <span>{latestCommit.filesChanged} files changed</span>
                         </>
                       )}
 
                       {typeof latestCommit.additions === "number" &&
                         typeof latestCommit.deletions === "number" && (
-                        <>
-                          <span className="mx-1 md:mx-2">
-                            •
-                          </span>
+                          <>
+                            <span className="mx-1 md:mx-2">•</span>
 
                             <span className="ml-2 text-green-600 dark:text-green-400 font-semibold">
                               +{latestCommit.additions}
@@ -399,7 +395,7 @@ export default async function Page() {
                             <span className="ml-2 text-red-600 dark:text-red-400 font-semibold">
                               −{latestCommit.deletions}
                             </span>
-                        </>
+                          </>
                         )}
 
                       {latestCommit.author_avatar ? (
@@ -425,9 +421,9 @@ export default async function Page() {
                           {latestCommit.author_login}
                         </a>
                       ) : latestCommit.author_name ? (
-                          <span className="ml-2">
-                            by {latestCommit.author_name}
-                          </span>
+                        <span className="ml-2">
+                          by {latestCommit.author_name}
+                        </span>
                       ) : null}
 
                       {latestCommit.date && (

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -102,24 +102,6 @@ function shortSha(sha?: string | null) {
   return sha.substring(0, 7);
 }
 
-function timeAgo(iso?: string | null) {
-  if (!iso) return "";
-  try {
-    const then = new Date(iso).getTime();
-    const now = Date.now();
-    const diff = Math.max(0, Math.floor((now - then) / 1000));
-    if (diff < 60) return `${diff}s ago`;
-    const mins = Math.floor(diff / 60);
-    if (mins < 60) return `${mins}m ago`;
-    const hrs = Math.floor(mins / 60);
-    if (hrs < 24) return `${hrs}h ago`;
-    const days = Math.floor(hrs / 24);
-    return `${days}d ago`;
-  } catch (e) {
-    return "";
-  }
-}
-
 async function fetchCommitDetails(repoFullName: string, sha: string) {
   try {
     const url = `https://api.github.com/repos/${repoFullName}/commits/${sha}`;

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -248,17 +248,36 @@ export default async function Page() {
               className="mb-6"
             >
               <div className="dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 rounded-lg">
-                <h3 className="font-incognito text-2xl font-bold tracking-tight mb-2">Last Commit</h3>
+                <div className="flex items-center justify-between mb-2">
+                  <h3 className="font-incognito text-2xl font-bold tracking-tight">Last Commit</h3>
+                  <a
+                    href={`https://github.com/${latestCommit.repo}/tree/${latestCommit.sha}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center px-4 py-1.5 border rounded bg-zinc-100 dark:bg-zinc-800 text-sm font-medium hover:bg-zinc-200 dark:hover:bg-zinc-700"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      focusable="false"
+                      className="octicon octicon-file-code w-4 h-4 mr-2 text-zinc-700 dark:text-zinc-200"
+                      viewBox="0 0 16 16"
+                      width="16"
+                      height="16"
+                      fill="currentColor"
+                      style={{ display: "inline-block", overflow: "visible", verticalAlign: "text-bottom" }}
+                    >
+                      <path d="M4 1.75C4 .784 4.784 0 5.75 0h5.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 14.25 15h-9a.75.75 0 0 1 0-1.5h9a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 10 4.25V1.5H5.75a.25.25 0 0 0-.25.25v2.5a.75.75 0 0 1-1.5 0Zm1.72 4.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.47-1.47-1.47-1.47a.75.75 0 0 1 0-1.06ZM3.28 7.78 1.81 9.25l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Zm8.22-6.218V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
+                    </svg>
+                    Browse files
+                  </a>
+                </div>
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
                   <div>
-                    <a
-                      href={latestCommit.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary-color font-semibold hover:underline"
-                    >
-                      {latestCommit.message || "View Commit"}
-                    </a>
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100">
+                        {latestCommit.message || "Commit message"}
+                      </div>
+                    </div>
                     <div className="mt-2 text-sm dark:text-zinc-400 text-zinc-600">
                       <a
                         href={`https://github.com/${latestCommit.repo}`}

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -9,6 +9,7 @@ import type {
 import StatsPie from "../../components/stats/stats-pie";
 import WakaTimeDisclaimer from "../../components/stats/wakatime-disclaimer";
 import GitHubCalendarClient from "../../components/github-calendar-client";
+import LocalTime from "../../components/local-time";
 
 async function fetchWaka(path: string) {
   const apiKey = process.env.WAKATIME_API_KEY;
@@ -437,15 +438,7 @@ export default async function Page() {
                         <span className="ml-2">by {latestCommit.author_name}</span>
                       ) : null}
 
-                      {latestCommit.date && (
-                        <time
-                          dateTime={latestCommit.date}
-                          title={new Date(latestCommit.date).toLocaleString()}
-                          className="ml-2 text-xs text-zinc-500 dark:text-zinc-500"
-                        >
-                          {timeAgo(latestCommit.date)}
-                        </time>
-                      )}
+                      {latestCommit.date && <LocalTime iso={latestCommit.date} />}
                     </div>
                   </div>
                 </div>

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -337,7 +337,7 @@ export default async function Page() {
                       >
                         {latestCommit.repo}
                       </a>
-                      <span className="mx-2">•</span>
+                      <span className="mx-1 md:mx-2">&nbsp;•</span>
 
                       <a
                         href={String(latestCommit.url)}
@@ -378,22 +378,28 @@ export default async function Page() {
                       </a>
 
                       {typeof latestCommit.filesChanged === "number" && (
-                        <span className="ml-2">
-                          • {latestCommit.filesChanged} files changed
-                        </span>
+                        <>
+                          <span className="mx-1 md:mx-2">&nbsp;•</span>
+                          <span>
+                            {latestCommit.filesChanged} files changed
+                          </span>
+                        </>
                       )}
 
                       {typeof latestCommit.additions === "number" &&
                         typeof latestCommit.deletions === "number" && (
-                          <span className="ml-2">
+                        <>
+                          <span className="mx-1 md:mx-2">
                             •
+                          </span>
+
                             <span className="ml-2 text-green-600 dark:text-green-400 font-semibold">
                               +{latestCommit.additions}
                             </span>
                             <span className="ml-2 text-red-600 dark:text-red-400 font-semibold">
                               −{latestCommit.deletions}
                             </span>
-                          </span>
+                        </>
                         )}
 
                       {latestCommit.author_avatar ? (

--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -241,10 +241,6 @@ export default async function Page() {
     // Total lines: prefer README badge fallback
     const totalLines = 0;
 
-    // We'll source recent branch/language from GitHub events instead of WakaTime.
-
-    // summaries removed (premium). Day-of-week averages are not available without premium summaries.
-
     // Try to read a fallback total-lines value from the repository README (badge)
     const readmeLines = await fetchReadmeLines();
     // Compute a link to the user's WakaTime profile when available
@@ -259,21 +255,29 @@ export default async function Page() {
     })();
 
     // fetch latest public commit (server-side)
-    const latestCommitRaw: LatestCommit | null = await fetchLatestPublicCommit();
+    const latestCommitRaw: LatestCommit | null =
+      await fetchLatestPublicCommit();
     let latestCommit: LatestCommit | null = latestCommitRaw;
-    if (latestCommitRaw) {
-      const details = await fetchCommitDetails(latestCommitRaw.repo, latestCommitRaw.sha);
+    if (latestCommitRaw?.repo && latestCommitRaw?.sha) {
+      const details = await fetchCommitDetails(
+        latestCommitRaw.repo,
+        latestCommitRaw.sha
+      );
       if (details) {
         latestCommit = {
           sha: latestCommitRaw.sha,
           repo: latestCommitRaw.repo,
           url: latestCommitRaw.url,
           message: details.commit?.message || latestCommitRaw.message,
-          author_name: details.commit?.author?.name || latestCommitRaw.author_name,
+          author_name:
+            details.commit?.author?.name || latestCommitRaw.author_name,
           author_login: details.author?.login || latestCommitRaw.author_login,
-          author_avatar: details.author?.avatar_url || latestCommitRaw.author_avatar,
+          author_avatar:
+            details.author?.avatar_url || latestCommitRaw.author_avatar,
           date: details.commit?.author?.date || latestCommitRaw.date,
-          filesChanged: Array.isArray(details.files) ? details.files.length : undefined,
+          filesChanged: Array.isArray(details.files)
+            ? details.files.length
+            : undefined,
           additions: details.stats?.additions ?? undefined,
           deletions: details.stats?.deletions ?? undefined,
         } as LatestCommit;
@@ -344,7 +348,9 @@ export default async function Page() {
             >
               <div className="dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 rounded-lg">
                 <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-incognito text-2xl font-bold tracking-tight">Last Commit</h3>
+                  <h3 className="font-incognito text-2xl font-bold tracking-tight">
+                    Last Commit
+                  </h3>
                   <a
                     href={`https://github.com/${latestCommit.repo}/tree/${latestCommit.sha}`}
                     target="_blank"
@@ -359,7 +365,11 @@ export default async function Page() {
                       width="16"
                       height="16"
                       fill="currentColor"
-                      style={{ display: "inline-block", overflow: "visible", verticalAlign: "text-bottom" }}
+                      style={{
+                        display: "inline-block",
+                        overflow: "visible",
+                        verticalAlign: "text-bottom",
+                      }}
                     >
                       <path d="M4 1.75C4 .784 4.784 0 5.75 0h5.586c.464 0 .909.184 1.237.513l2.914 2.914c.329.328.513.773.513 1.237v8.586A1.75 1.75 0 0 1 14.25 15h-9a.75.75 0 0 1 0-1.5h9a.25.25 0 0 0 .25-.25V6h-2.75A1.75 1.75 0 0 1 10 4.25V1.5H5.75a.25.25 0 0 0-.25.25v2.5a.75.75 0 0 1-1.5 0Zm1.72 4.97a.75.75 0 0 1 1.06 0l2 2a.75.75 0 0 1 0 1.06l-2 2a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734l1.47-1.47-1.47-1.47a.75.75 0 0 1 0-1.06ZM3.28 7.78 1.81 9.25l1.47 1.47a.751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018l-2-2a.75.75 0 0 1 0-1.06l2-2a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042Zm8.22-6.218V4.25c0 .138.112.25.25.25h2.688l-.011-.013-2.914-2.914-.013-.011Z"></path>
                     </svg>
@@ -375,7 +385,7 @@ export default async function Page() {
                       {commitSubject && (
                         <div className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 mb-2">
                           {commitSubject}
-                      </div>
+                        </div>
                       )}
                       {commitBody && (
                         <div className="mt-2 text-sm text-zinc-600 dark:text-zinc-400 whitespace-pre-wrap">
@@ -395,7 +405,7 @@ export default async function Page() {
                       <span className="mx-2">•</span>
 
                       <a
-                        href={latestCommit.url}
+                        href={String(latestCommit.url)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded"
@@ -408,37 +418,80 @@ export default async function Page() {
                           xmlns="http://www.w3.org/2000/svg"
                           aria-hidden="true"
                         >
-                          <path d="M14 3h7v7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                          <path d="M10 14L21 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-                          <path d="M21 21H3V3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                          <path
+                            d="M14 3h7v7"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d="M10 14L21 3"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                          <path
+                            d="M21 21H3V3"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
                         </svg>
                       </a>
 
                       {typeof latestCommit.filesChanged === "number" && (
-                        <span className="ml-2">• {latestCommit.filesChanged} files changed</span>
-                      )}
-
-                      {typeof latestCommit.additions === "number" && typeof latestCommit.deletions === "number" && (
-                        <span className="ml-2">•
-                          <span className="ml-2 text-green-600 dark:text-green-400 font-semibold">+{latestCommit.additions}</span>
-                          <span className="ml-2 text-red-600 dark:text-red-400 font-semibold">−{latestCommit.deletions}</span>
+                        <span className="ml-2">
+                          • {latestCommit.filesChanged} files changed
                         </span>
                       )}
 
+                      {typeof latestCommit.additions === "number" &&
+                        typeof latestCommit.deletions === "number" && (
+                          <span className="ml-2">
+                            •
+                            <span className="ml-2 text-green-600 dark:text-green-400 font-semibold">
+                              +{latestCommit.additions}
+                            </span>
+                            <span className="ml-2 text-red-600 dark:text-red-400 font-semibold">
+                              −{latestCommit.deletions}
+                            </span>
+                          </span>
+                        )}
+
                       {latestCommit.author_avatar ? (
                         // eslint-disable-next-line @next/next/no-img-element
-                        <img src={latestCommit.author_avatar} alt={latestCommit.author_login ?? latestCommit.author_name ?? "author"} className="w-6 h-6 rounded-full ml-2" />
+                        <img
+                          src={latestCommit.author_avatar}
+                          alt={
+                            latestCommit.author_login ??
+                            latestCommit.author_name ??
+                            "author"
+                          }
+                          className="w-6 h-6 rounded-full ml-2"
+                        />
                       ) : null}
 
                       {latestCommit.author_login ? (
-                        <a href={`https://github.com/${latestCommit.author_login}`} target="_blank" rel="noopener noreferrer" className="ml-2 font-medium text-primary-color hover:underline">
+                        <a
+                          href={`https://github.com/${latestCommit.author_login}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="ml-2 font-medium text-primary-color hover:underline"
+                        >
                           {latestCommit.author_login}
                         </a>
                       ) : latestCommit.author_name ? (
-                        <span className="ml-2">by {latestCommit.author_name}</span>
+                          <span className="ml-2">
+                            by {latestCommit.author_name}
+                          </span>
                       ) : null}
 
-                      {latestCommit.date && <LocalTime iso={latestCommit.date} />}
+                      {latestCommit.date && (
+                        <LocalTime iso={latestCommit.date} />
+                      )}
                     </div>
                   </div>
                 </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import GoogleAnalytics from "@/components/google-analytics";
 import { GA_MEASUREMENT_ID } from "@/lib/gtag";
 import { siteMetadata } from "@/lib/constants";
 import ScrollToTop from "@/components/scroll-to-top";
+import AOSInit from "@/components/aos-init";
 
 const inconsolata = Inconsolata({
   variable: "--font-inconsolata-mono",
@@ -85,6 +86,7 @@ export default function RootLayout({
           </>
         )}
         <Header />
+        <AOSInit />
         {children}
         <Footer />
         <ScrollToTop />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,49 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
 import GitHubCalendarClient from "@/components/github-calendar-client";
 import { socialLinks, highlights, projects } from "@/lib/constants";
-import { fetchLatestPublicCommit } from "@/lib/github";
 import { event } from "@/lib/gtag";
 
 export default function Home() {
-  // AOS initialization moved to root layout via <AOSInit />
-
-  const [commit, setCommit] = useState<{
-    sha: string;
-    message: string;
-    url: string;
-    repo: string;
-    author?: string;
-    date?: string;
-  } | null>(null);
-  const [commitLoading, setCommitLoading] = useState(true);
-
-  useEffect(() => {
-    async function fetchLatestCommit() {
-      try {
-        const c = await fetchLatestPublicCommit();
-        if (!c) {
-          setCommitLoading(false);
-          return;
-        }
-        setCommit({
-          sha: c.sha,
-          message: c.message || "",
-          url: c.url || `https://github.com/${c.repo}/commit/${c.sha}`,
-          repo: c.repo || "",
-          author: c.author_name || c.author_login || undefined,
-          date: String(c.date),
-        });
-        setCommitLoading(false);
-      } catch (e) {
-        setCommitLoading(false);
-      }
-    }
-    fetchLatestCommit();
-  }, []);
-
   return (
     <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20">
       {/* Hero Section with CTAs */}
@@ -299,64 +261,6 @@ export default function Home() {
               <p className="text-sm font-medium">{highlight}</p>
             </div>
           ))}
-        </div>
-      </section>
-
-      {/* Latest Commit Tile */}
-      <section
-        className="mb-8"
-        data-aos="fade-up"
-        data-aos-duration={800}
-        data-aos-once={true}
-      >
-        <div className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-4 shadow-sm">
-          <h3 className="font-incognito text-2xl mb-3 font-bold">
-            Latest Public Commit
-          </h3>
-          {commitLoading ? (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              Loading latest commit…
-            </p>
-          ) : commit ? (
-            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-              <div>
-                <a
-                  href={commit.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary-color font-semibold hover:underline"
-                >
-                  {commit.message || "View Commit"}
-                </a>
-                <div className="mt-2 text-sm dark:text-zinc-400 text-zinc-600">
-                  <a
-                    href={`https://github.com/${commit.repo}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="font-medium"
-                  >
-                    {commit.repo}
-                  </a>
-                  <span className="mx-2">&nbsp;•</span>
-                  <span className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded">
-                    {commit.sha.substring(0, 7)}
-                  </span>
-                  {commit.author && (
-                    <span className="ml-2">by {commit.author}</span>
-                  )}
-                  {commit.date && (
-                    <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-500">
-                      {new Date(commit.date).toLocaleString()}
-                    </span>
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">
-              No recent public commits found.
-            </p>
-          )}
         </div>
       </section>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home() {
           url: c.url || `https://github.com/${c.repo}/commit/${c.sha}`,
           repo: c.repo || "",
           author: c.author_name || c.author_login || undefined,
-          date: c.date,
+          date: String(c.date),
         });
         setCommitLoading(false);
       } catch (e) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -323,9 +323,13 @@ export default function Home() {
         data-aos-once={true}
       >
         <div className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-4 shadow-sm">
-          <h3 className="font-incognito text-2xl mb-3 font-bold">Latest Public Commit</h3>
+          <h3 className="font-incognito text-2xl mb-3 font-bold">
+            Latest Public Commit
+          </h3>
           {commitLoading ? (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">Loading latest commit…</p>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              Loading latest commit…
+            </p>
           ) : commit ? (
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div>
@@ -350,7 +354,9 @@ export default function Home() {
                   <span className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded">
                     {commit.sha.substring(0, 7)}
                   </span>
-                  {commit.author && <span className="ml-2">by {commit.author}</span>}
+                  {commit.author && (
+                    <span className="ml-2">by {commit.author}</span>
+                  )}
                   {commit.date && (
                     <span className="ml-2 text-xs text-zinc-500 dark:text-zinc-500">
                       {new Date(commit.date).toLocaleString()}
@@ -360,7 +366,9 @@ export default function Home() {
               </div>
             </div>
           ) : (
-            <p className="text-sm text-zinc-500 dark:text-zinc-400">No recent public commits found.</p>
+            <p className="text-sm text-zinc-500 dark:text-zinc-400">
+              No recent public commits found.
+            </p>
           )}
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -337,7 +337,7 @@ export default function Home() {
                   >
                     {commit.repo}
                   </a>
-                    <span className="mx-2">&nbsp;•</span>
+                  <span className="mx-2">&nbsp;•</span>
                   <span className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded">
                     {commit.sha.substring(0, 7)}
                   </span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -337,7 +337,7 @@ export default function Home() {
                   >
                     {commit.repo}
                   </a>
-                  <span className="mx-2">•</span>
+                    <span className="mx-2">&nbsp;•</span>
                   <span className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-2 py-1 rounded">
                     {commit.sha.substring(0, 7)}
                   </span>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import AOS from "aos";
 import type { ResumeData } from "@/types/resume";
 import { event } from "@/lib/gtag";
 
@@ -12,7 +11,6 @@ export default function Home() {
   const [shareSupported, setShareSupported] = useState(false);
 
   useEffect(() => {
-    AOS.init();
     setShareSupported(typeof navigator !== "undefined" && !!navigator.share);
   }, []);
 

--- a/components/aos-init.tsx
+++ b/components/aos-init.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+import AOS from "aos";
+
+export default function AOSInit() {
+  useEffect(() => {
+    try {
+      AOS.init({ once: true });
+    } catch (e) {
+      // noop - fail safe
+    }
+  }, []);
+
+  return null;
+}

--- a/components/github-calendar-client.tsx
+++ b/components/github-calendar-client.tsx
@@ -37,29 +37,29 @@ export default function GitHubCalendarClient({
   return (
     <>
       <div className="flex xl:flex-row flex-col gap-4 items-center">
-      <div className="dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 sm:p-8 rounded-lg w-full overflow-hidden">
-        {title && (
-          <h3 className="font-incognito text-2xl font-bold tracking-tight mb-2">
-            {title}
-          </h3>
-        )}
-        {description && (
-          <p className="text-sm dark:text-zinc-500 text-zinc-500 mb-4">
-            {description}
-          </p>
-        )}
-        <div className="overflow-x-auto -mx-6 sm:-mx-8 px-6 sm:px-8 py-2">
-          <div className="min-w-[320px]">
-            <GitHubCalendar
-              username={username}
-              year={Number(year)}
-              colorScheme={colorScheme}
-            />
+        <div className="dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 sm:p-8 rounded-lg w-full overflow-hidden">
+          {title && (
+            <h3 className="font-incognito text-2xl font-bold tracking-tight mb-2">
+              {title}
+            </h3>
+          )}
+          {description && (
+            <p className="text-sm dark:text-zinc-500 text-zinc-500 mb-4">
+              {description}
+            </p>
+          )}
+          <div className="overflow-x-auto -mx-6 sm:-mx-8 px-6 sm:px-8 py-2">
+            <div className="min-w-[320px]">
+              <GitHubCalendar
+                username={username}
+                year={Number(year)}
+                colorScheme={colorScheme}
+              />
+            </div>
           </div>
-        </div>
           {showDisclaimer && (
             <div className="w-full mt-3 text-sm text-zinc-500 dark:text-zinc-500 italic">
-              View more information on{' '}
+              View more information on{" "}
               <a
                 href="https://github.com/brignano"
                 target="_blank"
@@ -81,11 +81,13 @@ export default function GitHubCalendarClient({
               .
             </div>
           )}
-      </div>
+        </div>
 
-      <div className="flex justify-center xl:justify-start xl:flex-col flex-row flex-wrap gap-2">
-        {Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i).map(
-          (y) => (
+        <div className="flex justify-center xl:justify-start xl:flex-col flex-row flex-wrap gap-2">
+          {Array.from(
+            { length: 5 },
+            (_, i) => new Date().getFullYear() - i
+          ).map((y) => (
             <button
               key={y}
               title={`View graph for the year ${y}`}
@@ -105,9 +107,8 @@ export default function GitHubCalendarClient({
             >
               {y}
             </button>
-          )
-        )}
-      </div>
+          ))}
+        </div>
       </div>
     </>
   );

--- a/components/github-calendar-client.tsx
+++ b/components/github-calendar-client.tsx
@@ -58,7 +58,7 @@ export default function GitHubCalendarClient({
           </div>
         </div>
           {showDisclaimer && (
-            <div className="w-full mt-3 text-sm text-zinc-500 dark:text-zinc-500">
+            <div className="w-full mt-3 text-sm text-zinc-500 dark:text-zinc-500 italic">
               View more information on{' '}
               <a
                 href="https://github.com/brignano"

--- a/components/local-time.tsx
+++ b/components/local-time.tsx
@@ -5,14 +5,15 @@ import { useEffect, useState } from "react";
 type Props = { iso?: string | null };
 
 export default function LocalTime({ iso }: Props) {
-  if (!iso) return null;
-
+  // Hooks must be called unconditionally (Rules of Hooks).
   const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     const t = setInterval(() => setNow(Date.now()), 60_000);
     return () => clearInterval(t);
   }, []);
+
+  if (!iso) return null;
 
   const then = new Date(iso).getTime();
   const diff = Math.max(0, Math.floor((now - then) / 1000));

--- a/components/local-time.tsx
+++ b/components/local-time.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+type Props = { iso?: string | null };
+
+export default function LocalTime({ iso }: Props) {
+  if (!iso) return null;
+
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const t = setInterval(() => setNow(Date.now()), 60_000);
+    return () => clearInterval(t);
+  }, []);
+
+  const then = new Date(iso).getTime();
+  const diff = Math.max(0, Math.floor((now - then) / 1000));
+
+  let relative = "";
+  if (diff < 60) relative = `${diff}s ago`;
+  else {
+    const mins = Math.floor(diff / 60);
+    if (mins < 60) relative = `${mins}m ago`;
+    else {
+      const hrs = Math.floor(mins / 60);
+      if (hrs < 24) relative = `${hrs}h ago`;
+      else relative = `${Math.floor(hrs / 24)}d ago`;
+    }
+  }
+
+  const title = new Date(iso).toLocaleString(undefined, { timeZoneName: "short" });
+
+  return (
+    <time dateTime={iso} title={title} className="ml-2 text-xs text-zinc-500 dark:text-zinc-500">
+      {relative}
+    </time>
+  );
+}

--- a/components/local-time.tsx
+++ b/components/local-time.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 type Props = { iso?: string | null };
 
@@ -29,10 +29,16 @@ export default function LocalTime({ iso }: Props) {
     }
   }
 
-  const title = new Date(iso).toLocaleString(undefined, { timeZoneName: "short" });
+  const title = new Date(iso).toLocaleString(undefined, {
+    timeZoneName: "short",
+  });
 
   return (
-    <time dateTime={iso} title={title} className="ml-2 text-xs text-zinc-500 dark:text-zinc-500">
+    <time
+      dateTime={iso}
+      title={title}
+      className="ml-2 text-xs text-zinc-500 dark:text-zinc-500"
+    >
       {relative}
     </time>
   );

--- a/components/stats/wakatime-disclaimer.tsx
+++ b/components/stats/wakatime-disclaimer.tsx
@@ -24,7 +24,7 @@ export default function WakaTimeDisclaimer({ url }: WakaTimeDisclaimerProps) {
 
   return (
     <>
-      <span className="leading-none">🚀</span>
+      <span className="leading-none">🚀&nbsp;</span>
       <span>
         Powered by{" "}
         <a

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -7,6 +7,9 @@ export type LatestCommit = {
   author_login?: string | null;
   author_avatar?: string | null;
   date?: string | null;
+  filesChanged?: number | undefined;
+  additions?: number | undefined;
+  deletions?: number | undefined;
 };
 
 export async function fetchLatestPublicCommit(): Promise<LatestCommit | null> {

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,0 +1,41 @@
+export type LatestCommit = {
+  sha: string;
+  message?: string | null;
+  url?: string | null;
+  repo?: string | null;
+  author_name?: string | null;
+  author_login?: string | null;
+  author_avatar?: string | null;
+  date?: string | null;
+};
+
+export async function fetchLatestPublicCommit(): Promise<LatestCommit | null> {
+  try {
+    const res = await fetch("https://api.github.com/users/brignano/events/public", { next: { revalidate: 60 } });
+    if (!res.ok) return null;
+    const events = await res.json();
+    for (const ev of events) {
+      if (ev.type === "PushEvent" && ev.payload) {
+        const repo = ev.repo?.name;
+        const commits = ev.payload.commits;
+        const c = (commits && commits[0]) || ev.payload.head_commit;
+        const head = ev.payload.head || (c && c.sha) || null;
+        if (head && repo) {
+          return {
+            sha: head,
+            message: c?.message || "",
+            url: `https://github.com/${repo}/commit/${head}`,
+            repo,
+            author_name: c?.author?.name || null,
+            author_login: ev.actor?.login || null,
+            author_avatar: ev.actor?.avatar_url || null,
+            date: ev.created_at || null,
+          };
+        }
+      }
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -11,7 +11,10 @@ export type LatestCommit = {
 
 export async function fetchLatestPublicCommit(): Promise<LatestCommit | null> {
   try {
-    const res = await fetch("https://api.github.com/users/brignano/events/public", { next: { revalidate: 60 } });
+    const res = await fetch(
+      "https://api.github.com/users/brignano/events/public",
+      { next: { revalidate: 60 } }
+    );
     if (!res.ok) return null;
     const events = await res.json();
     for (const ev of events) {


### PR DESCRIPTION
This pull request introduces a new "Latest Commit" feature to both the coding and home pages, displaying the most recent public GitHub commit with enhanced details and improved UX. It also centralizes and optimizes AOS (Animate On Scroll) initialization, adds a reusable `LocalTime` component for relative timestamps, and includes minor UI/UX improvements and code cleanups.

**Latest Commit Feature:**

- Added logic on the coding page (`app/coding/page.tsx`) to fetch the latest public commit from GitHub, retrieve additional commit details (files changed, additions, deletions, author info), and render a styled "Last Commit" tile with subject/body, repo, SHA, stats, author, and relative time using the new `LocalTime` component. [[1]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR45-R105) [[2]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR147-R186) [[3]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR261-R291) [[4]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR336-R448) [[5]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR12) [[6]](diffhunk://#diff-6fcc9e2c4fb0d8e1548661e9ad030eb80f8837375d5d451303863cd696d524d4R1-R39)
- Added a similar "Latest Commit" tile to the home page (`app/page.tsx`) with client-side fetching and simplified details. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L4-R57) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R318-R367)

**AOS (Animate On Scroll) Initialization Improvements:**

- Moved AOS initialization to a new `AOSInit` component (`components/aos-init.tsx`) and mounted it globally in the root layout (`app/layout.tsx`), removing redundant AOS initialization from individual pages. [[1]](diffhunk://#diff-e88ff2023667596ffe92026d43f323b69f2c06c25e0f0fa2448c2ec8d411ae61R1-R16) [[2]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR13) [[3]](diffhunk://#diff-eca96d2c09f31517696a26e1d0be4070e1fbab02831481bed006e275741d030bR89) [[4]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L4-R57) [[5]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL4) [[6]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL15)

**UI/UX Enhancements:**

- Introduced the `LocalTime` component for displaying relative commit times with tooltips showing the full local time (`components/local-time.tsx`). [[1]](diffhunk://#diff-6fcc9e2c4fb0d8e1548661e9ad030eb80f8837375d5d451303863cd696d524d4R1-R39) [[2]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebR336-R448)
- Made minor text and style tweaks, such as clarifying WakaTime chart descriptions and italicizing the GitHub calendar disclaimer. [[1]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebL230-R476) [[2]](diffhunk://#diff-60a230060006f0ab4d206800603777801af50fd690929ba8cf90f5b6a58dd6ebL244-R490) [[3]](diffhunk://#diff-a3f3353318aee7a6fc06a23543043fbfeb1ffc2e56f3e305c3499aaf1ab34889L61-R61) [[4]](diffhunk://#diff-220a1e16cb77e4e9ef47b4cd9715beea73c60277ac20945fdcb8cfaec4b9a34dL27-R27)

**Code Cleanup:**

- Removed unused AOS imports and initialization from pages now handled by the global component. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0L4-R57) [[2]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL4) [[3]](diffhunk://#diff-a5b785c3ffb49da984a7500ded3bac0c137dd04408950109151ba71e63aeea8aL15)

These changes improve the visibility of recent coding activity, enhance user experience with better time displays, and streamline animation setup across the app.