### PR TITLE
Enhance highlights section layout for improved visual consistency

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -196,11 +196,11 @@ export default function Home() {
         data-aos-duration={800}
         data-aos-once={true}
       >
-        <div className="grid md:grid-cols-3 grid-cols-2 gap-4">
+        <div className="grid md:grid-cols-3 grid-cols-2 gap-4 auto-rows-fr">
           {highlights.map((highlight, index) => (
             <div
               key={index}
-              className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-4 shadow-sm w-full sm:w-auto text-center"
+              className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-4 shadow-sm w-full sm:w-auto text-center h-full min-h-24 flex items-center justify-center"
             >
               <p className="text-sm font-medium">{highlight}</p>
             </div>


### PR DESCRIPTION
This pull request makes a small update to the layout of the highlights grid on the homepage. The change ensures that highlight cards have a consistent height and are vertically centered within their grid cells.

* Added `auto-rows-fr` to the grid container and updated the highlight card classes to include `h-full min-h-24 flex items-center justify-center`, improving card alignment and sizing in `app/page.tsx`.