### PR TITLE
Fix breadcrumb schema property name

### DIFF
--- a/components/breadcrumb-schema.tsx
+++ b/components/breadcrumb-schema.tsx
@@ -17,7 +17,7 @@ export default function BreadcrumbSchema({ items }: BreadcrumbSchemaProps) {
       "@type": "ListItem",
       position: index + 1,
       name: item.name,
-      "@id": item.url,
+      item: item.url,
     })),
   };
 


### PR DESCRIPTION
Correct the breadcrumb schema by changing the property from "@id" to "item" to align with the expected format.