### PR TITLE
Ignore .claude/ tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@
 .DS_Store
 *.pem
 
+# claude code
+.claude/
+
 # debug
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
Add `.claude/` to `.gitignore`. This is Claude Code tooling config (e.g. `launch.json`), which is machine/workflow-specific and derivable from `package.json` — no value in tracking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)