### PR TITLE
fix: allow contributions API in CSP connect-src (contribution graph error)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -25,7 +25,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://www.google-analytics.com https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://github-contributions-api.jogruber.de https://www.google-analytics.com https://va.vercel-scripts.com https://vitals.vercel-insights.com; frame-ancestors 'none'"
         }
       ]
     },


### PR DESCRIPTION
## Problem

The contribution graph errors on the **production** site (works locally).

`react-github-calendar` fetches its data client-side from `https://github-contributions-api.jogruber.de`. That origin is **not** in the production CSP `connect-src` allowlist, so the browser blocks the request and the widget renders its error state. It works in local dev only because the dev server doesn't apply `vercel.json` headers.

Regression from when the CSP was tightened (`8d1d2f8`, "security/headers-and-env-example") — the contributions API was missed in the allowlist.

## Fix

Add `https://github-contributions-api.jogruber.de` to `connect-src` in [vercel.json](vercel.json). One line.

## Verification
- Live CSP confirmed missing the origin (`curl -I https://brignano.io`).
- The API itself is healthy (all years 2022–2026 return 200); the failure was purely the CSP block.

## Follow-up (not in this PR)
`jogruber.de` is a free, globally-shared proxy that rate-limits. A more robust long-term approach is to fetch contributions at build time with our own GitHub token and embed them, removing the runtime third-party dependency. Tracking separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)