### PR TITLE
feat: P2 content & SEO — positioning, copy, icons, footer, schema

### DIFF
--- a/app/coding/page.tsx
+++ b/app/coding/page.tsx
@@ -182,9 +182,6 @@ export default async function Page() {
         return "0 secs";
       })();
 
-    // Range helper text from all_time (e.g. "since Dec 11 2020")
-    const rangeText = allTime?.human_readable_range || null;
-
     // Total lines: prefer README badge fallback
     const totalLines = 0;
 
@@ -260,7 +257,7 @@ export default async function Page() {
             data-aos-delay="100"
             className="mt-1 text-xs text-zinc-500 dark:text-zinc-400 italic pl-1"
           >
-            ... {rangeText ?? "—"}
+            Tracked since Dec 2020
           </div>
 
           <div

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,7 +8,7 @@ import Footer from "@/components/footer";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import GoogleAnalytics from "@/components/google-analytics";
 import { GA_MEASUREMENT_ID } from "@/lib/gtag";
-import { siteMetadata } from "@/lib/constants";
+import { siteMetadata, socialLinks } from "@/lib/constants";
 import ScrollToTop from "@/components/scroll-to-top";
 import ScrollReveal from "@/components/scroll-reveal";
 import ToastProvider from "@/components/toast-provider";
@@ -88,6 +88,12 @@ export default function RootLayout({
   const twitterImage =
     getFirstImageUrl(siteMetadata.twitter?.images) ?? getFirstImageUrl(siteMetadata.openGraph?.images) ?? "/og.webp";
 
+  // Derive sameAs from the single source of truth (socialLinks); only http(s)
+  // profile URLs, not mailto. (TSD §5.7 Person schema enhancements.)
+  const sameAs = socialLinks
+    .map((link) => link.href)
+    .filter((href) => /^https?:\/\//.test(href));
+
   return (
     <html
       lang="en"
@@ -138,10 +144,19 @@ export default function RootLayout({
               name: "Anthony Brignano",
               url: "https://brignano.io",
               image: "https://brignano.io/headshot.jpeg",
-              sameAs: [
-                "https://www.linkedin.com/in/brignano",
-                "https://github.com/brignano",
+              description:
+                "Senior Staff Software Engineer building internal developer platforms, CI/CD ecosystems, DevOps intelligence, and AI-native tooling at enterprise scale.",
+              knowsAbout: [
+                "Platform Engineering",
+                "Developer Experience",
+                "CI/CD",
+                "DevOps Intelligence",
+                "AI-native tooling",
+                "GitHub Enterprise",
+                "Terraform",
+                "AWS",
               ],
+              sameAs,
               jobTitle: "Senior Staff Software Engineer",
               worksFor: {
                 "@type": "Organization",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,21 @@
 "use client";
 
 import Link from "next/link";
+import {
+  DocumentTextIcon,
+  CodeBracketIcon,
+  EnvelopeIcon,
+} from "@heroicons/react/24/outline";
 import GitHubCalendarClient from "@/components/github-calendar-client";
 import HeroMotif from "@/components/hero-motif";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
-import { socialLinks, highlights, projects, heroMetrics } from "@/lib/constants";
+import {
+  socialLinks,
+  achievements,
+  nowBuilding,
+  projects,
+  heroMetrics,
+} from "@/lib/constants";
 import { event } from "@/lib/gtag";
 
 const HOME_BREADCRUMBS = [
@@ -71,20 +82,7 @@ export default function Home() {
                 }}
               >
                 Resume
-                <svg
-                  className="ml-2 w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                  />
-                </svg>
+                <DocumentTextIcon className="ml-2 w-4 h-4" aria-hidden="true" />
               </Link>
               <Link
                 href="/coding"
@@ -98,20 +96,7 @@ export default function Home() {
                 }}
               >
                 Coding Activity
-                <svg
-                  className="ml-2 w-4 h-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M16 18l6-6-6-6M8 6L2 12l6 6"
-                  />
-                </svg>
+                <CodeBracketIcon className="ml-2 w-4 h-4" aria-hidden="true" />
               </Link>
             </div>
 
@@ -162,7 +147,10 @@ export default function Home() {
                     My work focuses on reducing friction and turning software delivery into a repeatable, paved road through automation, strong testing, and security as first-class concerns. My work sits at the intersection of platform engineering, developer experience, and emerging technologies, including AI-enabled tooling.
                   </p>
                   <p>
-                    Outside of work, you'll usually find me climbing rocks, snowboarding the glades, or exploring new ideas.
+                    Beyond the platform, I lead our enterprise hackathons, mentor emerging leaders as a rotation manager in the company&apos;s Leadership Development Program, and serve on the Central Connecticut State University (CCSU) Computer Science Industry Advisory Board.
+                  </p>
+                  <p>
+                    Outside of work, you'll usually find me climbing rocks, snowboarding through the woods, or exploring new ideas.
                   </p>
                 </div>
               </div>
@@ -170,22 +158,54 @@ export default function Home() {
           </div>
         </section>
 
-        {/* Highlights Strip */}
+        {/* Highlights — outcome cards + "Now" strip (TSD §5.5b) */}
         <section
           className="mb-24"
           data-aos="fade-up"
           data-aos-duration={800}
           data-aos-once={true}
         >
-          <div className="grid md:grid-cols-3 grid-cols-2 gap-4 auto-rows-fr">
-            {highlights.map((highlight, index) => (
+          {/* Tier 1 — quantified outcomes with skill pills */}
+          <div className="grid md:grid-cols-2 grid-cols-1 gap-4 auto-rows-fr">
+            {achievements.map((achievement, index) => (
               <div
                 key={index}
-                className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-4 shadow-sm w-full sm:w-auto text-center h-full min-h-24 flex items-center justify-center"
+                className="bg-white dark:bg-zinc-900 border dark:border-zinc-800 border-zinc-200 rounded-md px-6 py-5 shadow-sm h-full flex flex-col"
               >
-                <p className="text-sm font-medium">{highlight}</p>
+                <p className="text-base font-semibold tracking-tight mb-3">
+                  {achievement.outcome}
+                </p>
+                <div className="flex flex-wrap gap-2 mt-auto">
+                  {achievement.skills.map((skill) => (
+                    <span
+                      key={skill}
+                      className="text-xs px-2 py-1 dark:bg-zinc-800 bg-zinc-200 rounded"
+                    >
+                      {skill}
+                    </span>
+                  ))}
+                </div>
               </div>
             ))}
+          </div>
+
+          {/* Tier 2 — what I'm building now */}
+          <div className="mt-6">
+            <p className="font-silkscreen-mono uppercase tracking-[0.18em] text-[11px] text-primary-color mb-3">
+              Now building
+            </p>
+            <ul className="flex flex-wrap gap-x-6 gap-y-2 text-sm dark:text-zinc-400 text-zinc-600">
+              {nowBuilding.map((item) => (
+                <li key={item.label}>
+                  <span className="font-medium dark:text-zinc-200 text-zinc-800">
+                    {item.label}
+                  </span>{" "}
+                  <span className="dark:text-zinc-500 text-zinc-500">
+                    {item.detail}
+                  </span>
+                </li>
+              ))}
+            </ul>
           </div>
         </section>
 
@@ -267,28 +287,35 @@ export default function Home() {
                 Senior Staff Software Engineer — Enterprise Platform Engineering
               </h3>
               <p className="text-lg dark:text-zinc-300 text-zinc-700 mb-4">
-                I lead the strategy, design, and delivery of The Hartford's internal developer platform.
+                I lead the strategy, design, and delivery of The Hartford&apos;s internal developer platform — the single pane of glass 8,000+ engineers build on.
               </p>
               <p className="text-base dark:text-zinc-400 text-zinc-600 mb-4">
-                I own large-scale platform initiatives, including the migration of 11,000+ repositories to GitHub Enterprise Cloud, the design and operation of scalable CI/CD and governance platforms, and the adoption of next-generation developer tooling. My focus is on automation, reliability, and security as first-class concerns-reducing operational friction, accelerating developer productivity, and lowering incident rates across the enterprise.
+                My focus is automation, reliability, and security as first-class concerns — reducing operational friction and accelerating developer productivity across the enterprise.
               </p>
-              <ul className="list-disc list-inside mb-4">
-                <li>Leading development of AI-native platform capabilities, including MCP servers and a unified DevOps intelligence layer that enables AI agents to safely query and operate enterprise CI/CD systems</li>
-                <li>Architecting a first-class enterprise CLI that provides a consistent command surface for build execution, pipeline interaction, and developer workflows across platforms</li>
-                <li>Led enterprise migration to GitHub Enterprise Cloud (11,000+ repositories)</li>
+              <ul className="list-disc list-inside mb-4 space-y-2">
                 <li>
-                  Built and operated CI/CD, governance, and observability
-                  platforms
+                  On a CEO-sponsored initiative to make developer onboarding self-service — down from a 40+ day baseline.
                 </li>
                 <li>
-                  Rolled out next-gen CI/CD tooling, reducing developer-reported
-                  incidents
+                  A unified developer surface — custom CLI, desktop app, and IDE extensions — with 1,000+ engineers active in the first 90 days.
                 </li>
                 <li>
-                  Recognized with the 2023 Enterprise Tech Data & Cyber Award for
-                  platform adoption and productivity
+                  &ldquo;One build command, any stack&rdquo; — context-aware builds that run identically locally, in CI, or fully remote, on a custom base-image registry.
+                </li>
+                <li>
+                  Real-time DevOps intelligence — an event bus streaming pipeline and CLI/IDE telemetry into AWS, DynamoDB, and Snowflake for ML analysis of developer pain points; upgraded observability (Splunk, Dynatrace) and a live platform health status page with subscribe-able alerts.
+                </li>
+                <li>
+                  Native AI tooling and out-of-the-box skills (MCP, DevOps intelligence layer) built into the platform.
+                </li>
+                <li>
+                  Operate the enterprise CI/CD and DevSecOps toolchain end to end (Jenkins, GitHub Actions, Harness, AWS CodePipeline, Nexus, SonarQube, Checkmarx) keeping thousands of pipelines reliable.
                 </li>
               </ul>
+              <p className="text-sm dark:text-zinc-400 text-zinc-600 mb-4">
+                <span className="font-medium dark:text-zinc-300 text-zinc-700">Prior:</span>{" "}
+                migrated 10,000+ repos to GitHub Enterprise Cloud; recognized with the 2023 Enterprise Tech Data &amp; Cyber Award.
+              </p>
               <p className="text-sm dark:text-zinc-500 text-zinc-500 mt-4">
                 For my full career history, see{" "}
                 <Link href="/resume" className="underline text-primary-color">
@@ -310,7 +337,7 @@ export default function Home() {
           <div style={{ opacity: "1" }}>
             <div className="mb-4">
               <h2 className="font-incognito text-4xl font-bold tracking-tight mb-4">
-                Contribution Graph
+                Open-source activity
               </h2>
               <p className="dark:text-zinc-400 text-zinc-600 max-w-2xl">
                 GitHub contribution activity by year.
@@ -341,37 +368,15 @@ export default function Home() {
         >
           <div className="dark:bg-primary-bg bg-zinc-50 dark:border-zinc-800 border-zinc-200 border-2 p-16 rounded-xl text-center">
             <h2 className="font-incognito text-4xl mb-6 font-bold tracking-tight">
-              Want to collaborate or chat?
+              Let&apos;s build something.
             </h2>
             <p className="dark:text-zinc-400 text-zinc-600 mb-10 max-w-2xl mx-auto text-lg">
               If you're working on platform engineering, developer experience, or AI-native software delivery, I'd love to connect.
             </p>
-            <div className="flex flex-wrap justify-center gap-4">
-              <a
-                href="https://www.linkedin.com/in/brignano"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center px-8 py-4 border-2 dark:border-zinc-600 border-zinc-400 dark:hover:border-zinc-500 hover:border-zinc-500 dark:text-zinc-300 text-zinc-700 font-bold text-lg rounded-lg transition-all duration-200"
-                onClick={() => {
-                  event("cta_clicked", {
-                    cta: "linkedin_bottom",
-                    location: "bottom",
-                    transport_type: "beacon",
-                  });
-                }}
-              >
-                <svg
-                  className="w-5 h-5 mr-2"
-                  fill="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path d="M20 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h16a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1zM8.339 18.337H5.667v-8.59h2.672v8.59zM7.003 8.574a1.548 1.548 0 1 1 0-3.096 1.548 1.548 0 0 1 0 3.096zm11.335 9.763h-2.669V14.16c0-.996-.018-2.277-1.388-2.277-1.39 0-1.601 1.086-1.601 2.207v4.248h-2.667v-8.59h2.56v1.174h.037c.355-.675 1.227-1.387 2.524-1.387 2.704 0 3.203 1.778 3.203 4.092v4.71z" />
-                </svg>
-                LinkedIn
-              </a>
+            <div className="flex justify-center">
               <a
                 href="mailto:hi@brignano.io"
-                className="inline-flex items-center px-8 py-4 border-2 dark:border-zinc-600 border-zinc-400 dark:hover:border-zinc-500 hover:border-zinc-500 dark:text-zinc-300 text-zinc-700 font-bold text-lg rounded-lg transition-all duration-200"
+                className="inline-flex items-center px-8 py-4 bg-violet-600 hover:bg-violet-500 text-white font-bold text-lg rounded-lg transition-colors duration-200"
                 onClick={() => {
                   event("cta_clicked", {
                     cta: "contact_bottom",
@@ -380,20 +385,8 @@ export default function Home() {
                   });
                 }}
               >
-                <svg
-                  className="w-5 h-5 mr-2"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                  />
-                </svg>
-                Email
+                <EnvelopeIcon className="w-5 h-5 mr-2" aria-hidden="true" />
+                Get in touch
               </a>
             </div>
           </div>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -261,6 +261,7 @@ export default function Home() {
     personalInfo,
     summary,
     experience,
+    leadership,
     education,
     skills,
     certifications,
@@ -436,6 +437,38 @@ export default function Home() {
                   </div>
                 ))}
               </div>
+          </div>
+        </section>
+      )}
+
+      {/* Leadership & Community Section */}
+      {leadership && leadership.length > 0 && (
+        <section
+          className="mb-16"
+          data-aos="fade-up"
+          data-aos-duration={1000}
+          data-aos-once={true}
+        >
+          <h2 className="text-3xl mb-8 font-bold tracking-tight">
+            Leadership &amp; Community
+          </h2>
+          <div className="grid md:grid-cols-2 grid-cols-1 gap-6">
+            {leadership.map((item, index) => (
+              <div
+                key={index}
+                className="dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 rounded-lg"
+              >
+                <h3 className="text-lg font-semibold">{item.organization}</h3>
+                <p className="text-sm text-primary-color font-medium mb-2">
+                  {item.role}
+                </p>
+                {item.description && (
+                  <p className="text-sm dark:text-zinc-400 text-zinc-600">
+                    {item.description}
+                  </p>
+                )}
+              </div>
+            ))}
           </div>
         </section>
       )}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,62 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import { socialLinks } from "@/lib/constants";
-
-interface BuildTool {
-  name: string;
-  url: string;
-  logo: string;
-}
-
-const buildTools: BuildTool[] = [
-  {
-    name: "Next.js",
-    url: "https://nextjs.org/",
-    logo: "nextjs.svg",
-  },
-  {
-    name: "Terraform",
-    url: "https://developer.hashicorp.com/terraform",
-    logo: "terraform.svg",
-  },
-  {
-    name: "AWS",
-    url: "https://aws.amazon.com",
-    logo: "aws.svg",
-  },
-];
 
 export default function Footer() {
   return (
     <footer className="border-t dark:border-zinc-800 border-zinc-100 mt-10 sm:mt-32 lg:mt-24 lg:min-h-[250px] min-h-0 relative">
-      <div className="max-w-7xl mx-auto flex lg:flex-row flex-col items-center lg:justify-between justify-center gap-y-3 md:px-16 px-6 py-10 lg:py-16">
-        <div className="order-2 lg:order-1 flex md:flex-row flex-col items-center gap-x-2">
-          <h3>Built with: </h3>
-          <ul className="flex items-center gap-x-2 text-sm dark:text-zinc-400 text-zinc-500 md:mt-0 mt-2">
-            {buildTools.map((tool) => (
-              <li key={tool.name}>
-                <Link
-                  href={tool.url}
-                  target="_blank"
-                  className="flex items-center gap-x-2 dark:text-white text-zinc-600 hover:underline"
-                >
-                  <Image
-                    alt={`${tool.name} Logo`}
-                    src={tool.logo}
-                    width={20}
-                    height={20}
-                    className="dark:invert"
-                  />
-                  {tool.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="order-1 lg:order-2 flex items-center gap-x-4 mb-4 lg:mb-0">
+      <div className="max-w-7xl mx-auto flex lg:flex-row flex-col items-center lg:justify-between justify-center gap-y-4 md:px-16 px-6 py-10 lg:py-16">
+        <div className="order-1 lg:order-2 flex items-center gap-x-4">
           {socialLinks.map((link) => (
             <Link
               key={link.name}
@@ -71,7 +22,7 @@ export default function Footer() {
           ))}
         </div>
 
-        <div className="order-3 flex flex-col lg:items-end items-center lg:text-start text-center">
+        <div className="order-2 lg:order-1 flex flex-col lg:items-start items-center lg:text-start text-center">
           <small className="text-zinc-600 dark:text-zinc-400">
             Copyright © Anthony Brignano {new Date().getFullYear()} All rights
             Reserved

--- a/components/resume-pdf.tsx
+++ b/components/resume-pdf.tsx
@@ -207,10 +207,9 @@ const ResumePDF: React.FC<ResumePDFProps> = ({ data }) => {
     personalInfo,
     summary,
     experience,
-    education,
+    leadership,
     skills,
     certifications,
-    projects,
   } = data;
 
   return (
@@ -300,6 +299,24 @@ const ResumePDF: React.FC<ResumePDFProps> = ({ data }) => {
                     ))}
                   </View>
                 )}
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Leadership & Community Section */}
+        {leadership && leadership.length > 0 && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Leadership &amp; Community</Text>
+            {leadership.map((item, index) => (
+              <View key={index} style={styles.certificationItem}>
+                <Text style={styles.certificationName}>
+                  {item.organization}
+                </Text>
+                <Text style={styles.certificationIssuer}>
+                  {item.role}
+                  {item.description && ` — ${item.description}`}
+                </Text>
               </View>
             ))}
           </View>

--- a/docs/tsd-site-modernization.md
+++ b/docs/tsd-site-modernization.md
@@ -81,7 +81,7 @@ Findings from the review of the live site and source (desktop + mobile, light + 
 | Where | Current | Proposed |
 |---|---|---|
 | Hero H1 | "I design enterprise developer platforms that help thousands of engineers ship software safely and quickly." | "I build the platforms thousands of engineers ship on." |
-| Hero metrics *(new)* | — | `11,000+ repos migrated · 2023 Enterprise Tech Award · ~1.9M lines` |
+| Hero metrics *(new)* | — | `10,000+ repos migrated · 2023 Enterprise Tech Award · ~1.9M lines` *(superseded by §5.7)* |
 | CTA | "My Resume" | "Résumé" (primary, filled) |
 | CTA | "My Coding" | "Coding Activity" |
 | Heading | "Contribution Graph" | "Open-source activity" |
@@ -92,7 +92,7 @@ Findings from the review of the live site and source (desktop + mobile, light + 
 ### 5.5b Highlights — best of both (replaces the buzzword boxes)
 A two-tier block that serves execs/recruiters (proof) *and* devs (range), without two separate sections:
 
-- **Tier 1 — Achievements (outcome + tech):** each card leads with a quantified outcome headline and carries a small row of skill pills underneath. Example: **"11,000+ repos onto one paved road"** · `GitHub Enterprise` `CI/CD` `Terraform`. ~3–4 cards drawn from real outcomes (migration, incident reduction, AI/MCP layer, the 2023 award).
+- **Tier 1 — Achievements (outcome + tech):** each card leads with a quantified outcome headline and carries a small row of skill pills underneath. Example: **"10,000+ repos onto one paved road"** · `GitHub Enterprise` `CI/CD` `Terraform`. ~3–4 cards drawn from real outcomes (migration, incident reduction, AI/MCP layer, the 2023 award).
 - **Tier 2 — "Now" strip (personal + momentum):** a compact, low-effort line showing what you're currently building — signals you're hands-on and current. Drawn from real work: **homelab** (Proxmox/Docker/Tailscale), **local-LLM routing** (Ollama + Open WebUI), and **AI-native tooling with Claude Code**. One line each, no deep pages.
 
 This gives the "best of both worlds" (outcomes *and* skills) and gives your homelab / Claude Code work a home **now**, cheaply — while full write-ups stay deferred to the Work TSD (§9). Source all of it from `lib/constants.ts` so it's edit-in-one-place.
@@ -104,6 +104,47 @@ This gives the "best of both worlds" (outcomes *and* skills) and gives your home
 
 ### 5.6 Theme FOUC
 - Add a tiny **blocking inline script in `<head>`** that resolves theme from `localStorage`/`matchMedia` and sets the `dark` class before first paint. Fold the `localStorage` write into the toggle handler instead of a mount effect.
+
+### 5.7 P2 — resolved content & SEO (working session 2026-06-08)
+Decisions reached after P1; folds into the P2 PR. **Positioning shift:** lead with the *live platform suite*; the 10k-repo migration + 2023 award become **prior wins**, not the headline.
+
+**Integrity rules (non-negotiable — these are public claims about a named employer):**
+- `40+ days` is the **old onboarding baseline only**. The **1-day** target is a **CEO-sponsored *initiative/goal*** — never state it as delivered.
+- **No timeframe SLAs** in copy ("within an hour", "same-day", "first PR in 20 min" all cut — user declined that level of commitment). Make the *point* (fast, self-service onboarding) qualitatively.
+- Incident/ticket reduction is **not monitored yet** → **no hard numbers**; at most a design goal.
+- `8,000+` = **reach/mandate** (frame as "for"/"serving 8,000+ engineers", **never** "8,000 active users"). `1,000+` = current **90-day active adopters** (traction). Keep these distinct so they survive interview scrutiny.
+- **Repos migrated = `10,000+`, not 11,000+.** The Server source had ~10.3–10.5k repos; the ~500–700 that brought Cloud to 11k+ were **net-new created in Cloud**, not migrated. "Migrated/modernized" claims use **`10,000+`** (true and conservative). The 11k figure is only honest as an **end-state/scale** claim ("11,000+ repos on GitHub Enterprise Cloud"), a different verb — not used in current copy.
+
+**Hero metric strip** (replaces `~1.9M lines`; source from `lib/constants.ts` `heroMetrics`):
+> `8,000+` enterprise developers · `1,000+` active in 90 days · `10,000+` repos migrated
+
+**Homepage Current Role — curated pillars (6 + prior):**
+1. Lead the internal developer platform — single pane of glass for **8,000+ engineers** — on a CEO-sponsored initiative to cut onboarding from **40+ days**.
+2. Unified developer surface: **custom CLI, desktop app, IDE extensions**; **1,000+ active in 90 days**.
+3. **"One build command, any stack"** — context-aware builds that run identically locally / in CI / fully remote, on a custom base-image registry.
+4. **Real-time DevOps intelligence** — an event bus streaming pipeline + CLI/IDE telemetry into **AWS, DynamoDB, Snowflake** for ML analysis of developer pain points; upgraded observability (**Splunk, Dynatrace**); live platform **health status page + subscribe-able alerts**.
+5. **Native AI tooling + out-of-the-box skills** (MCP, DevOps intelligence layer) built in.
+6. Operate the enterprise **CI/CD + DevSecOps toolchain** end to end (Jenkins, GitHub Actions, Harness, AWS CodePipeline, Nexus, SonarQube, Checkmarx, …) keeping thousands of pipelines reliable.
+- *Prior:* migrated **10,000+ repos** → GitHub Enterprise Cloud; **2023 Enterprise Tech Award** (year reads as context here, not a headline metric).
+
+**Homepage About — add a leadership/community line** (between platform paragraph and hobbies):
+> *Beyond the platform, I lead our enterprise hackathons, mentor emerging leaders as a rotation manager in the company's Leadership Development Program, and serve on the CCSU Computer Science Industry Advisory Board.*
+- Also apply the already-staged tweak: "snowboarding the glades" → **"snowboarding through the woods"** (uncommitted in working tree as of this session).
+
+**Résumé (`app/resume/page.tsx`):**
+- Expanded Current Role bullets (comprehensive version of the 6 pillars above + virtual tasks / remote build detail that was trimmed from the homepage).
+- New **"Leadership & Community"** section: **Enterprise Hackathons** (lead/organizer) · **Leadership Development Program** — Rotation Manager · **CCSU Computer Science Industry Advisory Board** — Member.
+- **Skills/Tech** section grouped (recruiter/ATS keyword home for the full tool inventory): **CI/CD** (Jenkins, GitHub Actions, Harness, AWS CodePipeline, uDeploy) · **DevSecOps** (Checkmarx, SonarQube, NexusIQ) · **Artifact & Quality** (Nexus) · **Observability** (Splunk, Dynatrace) · **Cloud & Data** (AWS, DynamoDB, Snowflake) · **Platform/VCS** (GitHub Enterprise) · **AI** (MCP).
+
+**SEO / metadata (`lib/constants.ts` `siteMetadata` + `app/layout.tsx` Person schema):**
+- **Title:** `Anthony Brignano — I build platforms engineers ship on` (decision: brand impression > keyword density, since the site ranks #1 on the name anyway; keywords live in the description).
+- **Description:** `Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes developer onboarding self-service and software delivery faster and safer.`
+- Mirror to OG + Twitter titles/descriptions.
+- **`Person` schema enhancements:** add `description`, `knowsAbout` (platform engineering, developer experience, CI/CD, DevOps intelligence, AI-native tooling, GitHub Enterprise, Terraform, AWS), and a fuller `sameAs` (pull from `socialLinks`). Off-page lever to mention to user: link brignano.io from LinkedIn + GitHub profiles.
+
+**Still in scope from original §5.4/§5.5:** footer "Built with" badge removal, `@heroicons/react` sweep (drop hand-rolled `<path>` SVGs incl. the two hero CTA icons), Highlights §5.5b redesign (outcome cards + skill pills + "Now" strip), `/coding` eyebrow copy, final CTA → "Let's build something."
+
+**Open confirmation:** ✅ **Resolved** — **CCSU** = Central Connecticut State University (confirmed against `public/resume.yml` education); spelled out once on the homepage About line and in the résumé Leadership & Community section.
 
 ## 6. Phasing
 
@@ -138,7 +179,7 @@ graph LR
 - `next build` (static export) succeeds; bundle size for `/coding` not increased.
 
 ## 9. Out of scope / future TSD: "Work" section
-The highest-impact credibility + stickiness lever is **2–3 case studies** (11k-repo migration; AI/MCP DevOps-intelligence layer; enterprise CLI) with problem → constraints → build → measurable outcome, plus a `/work` route and IA expansion. Tracked separately because it is a content effort, not a visual refresh.
+The highest-impact credibility + stickiness lever is **2–3 case studies** (10k-repo migration; AI/MCP DevOps-intelligence layer; enterprise CLI) with problem → constraints → build → measurable outcome, plus a `/work` route and IA expansion. Tracked separately because it is a content effort, not a visual refresh.
 
 ## 10. Decisions — RESOLVED
 1. **Base sans font:** ✅ **Geist Sans** (modern, self-hosted via `next/font`, memorable when paired with Silkscreen accent). §5.2

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,11 +8,16 @@ export interface SocialLink {
   icon: ReactNode;
 }
 
+// Brand impression > keyword density in the title (the site ranks #1 on the
+// name already); keywords live in the description (TSD §5.7).
+const SITE_TITLE = "Anthony Brignano — I build platforms engineers ship on";
+const SITE_DESCRIPTION =
+  "Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes developer onboarding self-service and software delivery faster and safer.";
+
 export const siteMetadata: Metadata = {
   metadataBase: new URL("https://brignano.io"),
-  title: "Anthony Brignano | Platform Engineering & DevEx",
-  description:
-    "Senior Staff Platform Engineer building internal developer platforms, CI/CD systems, DevOps intelligence, and AI-native delivery at enterprise scale.",
+  title: SITE_TITLE,
+  description: SITE_DESCRIPTION,
   icons: {
     icon: [
       { url: "/favicon.svg" },
@@ -21,9 +26,8 @@ export const siteMetadata: Metadata = {
   },
   manifest: "/manifest.json",
   openGraph: {
-    title: "Anthony Brignano | Platform Engineering, Developer Experience & AI",
-    description:
-      "Senior Staff Platform Engineer building internal developer platforms, CI/CD ecosystems, DevOps intelligence, and AI-native software delivery at enterprise scale.",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     url: "https://brignano.io",
     siteName: "Anthony Brignano",
     images: [
@@ -39,9 +43,8 @@ export const siteMetadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Anthony Brignano | Platform Engineering, Developer Experience & AI",
-    description:
-      "Senior Staff Platform Engineer focused on developer experience and internal platforms—CI/CD, DevOps intelligence, and AI-native delivery at enterprise scale.",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
     images: ["/og.webp"],
   },
   alternates: {
@@ -234,19 +237,52 @@ export interface HeroMetric {
 
 // Single source of truth for the hero proof strip. Keep these current —
 // they render directly under the hero subhead (above the fold).
+// Integrity (TSD §5.7): 8,000+ = reach/mandate ("for" engineers, not active
+// users); 1,000+ = current 90-day active adopters. Keep the framing distinct.
 export const heroMetrics: HeroMetric[] = [
-  { value: "11,000+", label: "repos migrated" },
-  { value: "2023", label: "Enterprise Tech Award" },
-  { value: "~1.9M", label: "lines of code" },
+  { value: "8,000+", label: "enterprise developers" },
+  { value: "1,000+", label: "active in 90 days" },
+  { value: "10,000+", label: "repos migrated" },
 ];
 
-export const highlights = [
-  "Cloud platforms & infrastructure (AWS / GCP)",
-  "Security-first software delivery (DevSecOps)",
-  "CI/CD automation & developer experience",
-  "Platform engineering & internal developer platforms",
-  "Observability, reliability & platform operations",
-  "AI-native delivery & developer tooling",
+export interface Achievement {
+  outcome: string;
+  skills: string[];
+}
+
+// Tier 1 — outcome cards with skill pills (TSD §5.5b). Each leads with a
+// quantified outcome and carries the tech underneath. Public claims about a
+// named employer: 8,000+ is reach, 1,000+ is 90-day adopters, no SLAs, no
+// incident numbers (TSD §5.7 integrity rules).
+export const achievements: Achievement[] = [
+  {
+    outcome: "A unified developer platform for 8,000+ engineers",
+    skills: ["GitHub Enterprise", "Custom CLI", "IDE Extensions"],
+  },
+  {
+    outcome: "1,000+ engineers active in the first 90 days",
+    skills: ["Desktop App", "CLI", "Self-service onboarding"],
+  },
+  {
+    outcome: "One build command, any stack — local, CI, or fully remote",
+    skills: ["CI/CD", "Base-image registry", "Containers"],
+  },
+  {
+    outcome: "Real-time DevOps intelligence for engineers and AI agents",
+    skills: ["MCP", "AWS", "DynamoDB", "Snowflake"],
+  },
+];
+
+export interface NowItem {
+  label: string;
+  detail: string;
+}
+
+// Tier 2 — "Now" momentum strip (TSD §5.5b): hands-on, current personal work.
+export const nowBuilding: NowItem[] = [
+  { label: "Homelab", detail: "Proxmox · Docker · Tailscale" },
+  { label: "Local-LLM routing", detail: "Ollama · Open WebUI" },
+  { label: "AI-native tooling", detail: "Claude Code" },
 ];
 
 export const projects: Project[] = [];

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -15,25 +15,27 @@ experience:
     startDate: 2023
     endDate: Present
     summary: |
-      Technical Lead for The Hartford's enterprise developer platform and developer experience strategy, owning the architecture and evolution of CI/CD, DevOps intelligence, internal developer portals, and AI/ML delivery patterns across thousands of repositories.
+      Technical Lead for The Hartford's enterprise developer platform and developer experience strategy — the single pane of glass serving 8,000+ engineers — owning the architecture and evolution of CI/CD, DevOps intelligence, internal developer tooling, and AI-native delivery patterns across thousands of repositories.
     highlights:
-      - Led enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud, modernizing 11,000+ repositories in under 12 months
-      - Principal architect for the enterprise developer platform, defining long-term strategy for developer experience, delivery automation, and AI-native software delivery
-      - Designed and rolled out internal developer platform capabilities (standardized pipelines, self-service workflows, opinionated paved roads)
-      - Built an enterprise CLI providing a single command surface for build execution, pipeline interaction, and developer workflows
-      - Architected a unified DevOps intelligence layer aggregating SDLC signals into actionable context for developers, platforms, and AI agents
-      - Drove platform-wide developer telemetry and workflow instrumentation to improve reliability, productivity, and time-to-resolution
-      - Provided architectural leadership across a heterogeneous CI/CD ecosystem (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UrbanCode Deploy)
+      - Lead the strategy, design, and delivery of the internal developer platform serving 8,000+ engineers, on a CEO-sponsored initiative to make developer onboarding self-service, down from a 40+ day baseline
+      - Shipped a unified developer surface across a custom CLI, desktop app, and IDE extensions, reaching 1,000+ active engineers in the first 90 days
+      - Designed "one build command, any stack" — context-aware builds that run identically locally, in CI, or fully remote on virtual build agents, against a custom base-image registry
+      - Architected a real-time DevOps intelligence layer — an event bus streaming pipeline plus CLI/IDE telemetry into AWS, DynamoDB, and Snowflake for ML analysis of developer pain points
+      - Upgraded platform observability (Splunk, Dynatrace) and stood up a live platform health status page with subscribe-able alerts
+      - Built native AI tooling into the platform — MCP servers and out-of-the-box skills that let AI agents safely query and operate enterprise CI/CD systems
+      - Operate the enterprise CI/CD and DevSecOps toolchain end to end (Jenkins, GitHub Actions, Harness, AWS CodePipeline, Nexus, SonarQube, Checkmarx) keeping thousands of pipelines reliable
+      - Led the enterprise migration from GitHub Enterprise Server to GitHub Enterprise Cloud, modernizing 10,000+ repositories in under 12 months
       - Enabled AI/ML delivery at scale via standardized platform patterns and pipelines for Google Cloud and Vertex AI workloads
-      - Led next-generation CI/CD tooling adoption and platform governance to improve consistency without sacrificing developer autonomy
       - Recognized with the 2023 Enterprise Tech Data & Cyber Award for platform adoption and productivity impact
     technologies:
       - Internal Developer Platforms (IDP)
-      - CI/CD Platforms (GitHub Actions, Harness, Jenkins, AWS CodePipeline, UCD)
-      - Cloud Platforms (AWS, Google Cloud Platform)
-      - AI/ML Platforms (Vertex AI)
+      - GitHub Enterprise Cloud
+      - CI/CD (GitHub Actions, Harness, Jenkins, AWS CodePipeline, uDeploy)
+      - DevSecOps (Checkmarx, SonarQube, Nexus)
+      - Cloud & Data (AWS, DynamoDB, Snowflake, Google Cloud)
+      - Observability (Splunk, Dynatrace)
+      - AI (MCP)
       - Infrastructure as Code (Terraform)
-      - Observability & Telemetry (Dynatrace)
   - company: The Hartford
     position: Staff Software Engineer — Enterprise Quality Engineering
     location: Hartford, CT
@@ -118,6 +120,47 @@ experience:
       - Sumo Logic
       - SOAP
       - REST
+leadership:
+  - organization: Enterprise Hackathons
+    role: Lead / Organizer
+    description: Lead and organize The Hartford's enterprise hackathons.
+  - organization: Leadership Development Program
+    role: Rotation Manager
+    description: Mentor emerging leaders as a rotation manager in the company's Leadership Development Program.
+  - organization: Central Connecticut State University — Computer Science Industry Advisory Board
+    role: Member
+    description: Serve on the CCSU Computer Science Industry Advisory Board.
+skills:
+  - category: CI/CD
+    items:
+      - Jenkins
+      - GitHub Actions
+      - Harness
+      - AWS CodePipeline
+      - uDeploy
+  - category: DevSecOps
+    items:
+      - Checkmarx
+      - SonarQube
+      - NexusIQ
+  - category: Artifact & Quality
+    items:
+      - Nexus
+  - category: Observability
+    items:
+      - Splunk
+      - Dynatrace
+  - category: Cloud & Data
+    items:
+      - AWS
+      - DynamoDB
+      - Snowflake
+  - category: Platform / VCS
+    items:
+      - GitHub Enterprise
+  - category: AI
+    items:
+      - MCP
 education:
   - institution: Central Connecticut State University
     degree: Bachelor of Science

--- a/types/resume.ts
+++ b/types/resume.ts
@@ -2,10 +2,17 @@ export interface ResumeData {
   personalInfo: PersonalInfo;
   summary: string;
   experience: Experience[];
+  leadership?: LeadershipRole[];
   education?: Education[];
   skills?: Skill[];
   certifications?: Certification[];
   projects?: Project[];
+}
+
+export interface LeadershipRole {
+  organization: string;
+  role: string;
+  description?: string;
 }
 
 export interface PersonalInfo {


### PR DESCRIPTION
Implements **TSD §5.7** (P2 — resolved content & SEO). Branched off the merged P1 (`main`). **Positioning shift:** lead with the live platform suite; the 10k-repo migration + 2023 award become *prior wins*.

## Content (homepage)
- **Hero metric strip** → `8,000+ enterprise developers · 1,000+ active in 90 days · 10,000+ repos migrated` (drops `~1.9M lines`).
- **Highlights (§5.5b)**: 6 buzzword boxes → 4 outcome cards with skill pills + a "Now building" momentum strip (homelab / local-LLM / Claude Code), sourced from `lib/constants.ts`.
- **Current Role**: rewritten to the 6 curated pillars + a "Prior" line; dropped the unmonitored incident-reduction claim.
- **About**: added the leadership/community line (hackathons, LDP rotation manager, CCSU advisory board); CCSU spelled out once.
- **Final CTA** → "Let's build something." with a single filled **Get in touch** button. Contribution heading → **Open-source activity**.

## Résumé (data-driven → also in the PDF)
- Expanded Current Role bullets (6 pillars + remote/virtual build detail).
- New **Leadership & Community** section.
- Grouped **Skills/Tech** section (CI/CD, DevSecOps, Artifact & Quality, Observability, Cloud & Data, Platform/VCS, AI).

## Icons / footer
- Replaced hand-rolled hero + contact `<path>` SVGs with `@heroicons/react`.
- Removed the inaccurate "Built with" footer badges; kept socials + copyright.

## SEO
- Title → `Anthony Brignano — I build platforms engineers ship on`; new keyword-rich description, mirrored to OG + Twitter.
- `Person` schema: added `description`, `knowsAbout`; `sameAs` derived from `socialLinks`.

## `/coding`
- Eyebrow → "Tracked since Dec 2020".

## Integrity (public claims about a named employer)
Follows the §5.7 non-negotiables: `8,000+` = reach, `1,000+` = 90-day adopters, no SLAs, no incident numbers, 1-day onboarding only as a CEO-sponsored *goal*. **"Repos migrated" stated as `10,000+`, not 11,000+** — the Server source held ~10.3–10.5k; the ~500–700 that brought Cloud to 11k+ were net-new in Cloud, not migrated.

## Verification
- `next build` (static export) passes; `tsc` clean.
- Homepage + résumé verified in **light and dark**, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)