### PR TITLE
feat(resume): expand skills with tech-logo badges

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import yaml from "js-yaml";
 import type { ResumeData } from "@/types/resume";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
+import { SkillBadge } from "@/components/skill-badge";
 import { event } from "@/lib/gtag";
 
 // `ResumePDF` and `@react-pdf/renderer` are imported dynamically in the
@@ -550,11 +551,8 @@ export default function Home() {
                 </h3>
                 <ul className="skill-items flex flex-wrap gap-2">
                   {skillGroup.items.map((skill, i) => (
-                    <li
-                      key={i}
-                      className="text-sm px-3 py-1 dark:bg-zinc-800 bg-zinc-200 rounded"
-                    >
-                      {skill}
+                    <li key={i} className="flex">
+                      <SkillBadge name={skill} />
                     </li>
                   ))}
                 </ul>

--- a/components/skill-badge.tsx
+++ b/components/skill-badge.tsx
@@ -1,0 +1,137 @@
+import {
+  siTypescript,
+  siJavascript,
+  siOpenjdk,
+  siDotnet,
+  siPython,
+  siGnubash,
+  siReact,
+  siNextdotjs,
+  siAngular,
+  siNodedotjs,
+  siSpringboot,
+  siTailwindcss,
+  siJenkins,
+  siGithubactions,
+  siTerraform,
+  siDocker,
+  siProxmox,
+  siPortainer,
+  siGooglecloud,
+  siSnowflake,
+  siPostgresql,
+  siModelcontextprotocol,
+  siOllama,
+  siCheckmarx,
+  siSonarqubeserver,
+  siSonatype,
+  siSelenium,
+  siCypress,
+  siApachemaven,
+  siSplunk,
+  siDynatrace,
+  siSumologic,
+  siGrafana,
+  siPrometheus,
+  siGithub,
+  siVercel,
+  siTailscale,
+} from "simple-icons";
+import type { SimpleIcon } from "simple-icons";
+
+// Map a skill name (as it appears in resume.yml) to its brand icon.
+// Names with no entry render as a plain text pill — no logo, no breakage.
+const NAME_TO_ICON: Record<string, SimpleIcon> = {
+  // Languages
+  TypeScript: siTypescript,
+  JavaScript: siJavascript,
+  Java: siOpenjdk,
+  "C# / .NET": siDotnet,
+  ".NET": siDotnet,
+  Python: siPython,
+  Bash: siGnubash,
+  // Frameworks & UI
+  React: siReact,
+  "Next.js": siNextdotjs,
+  Angular: siAngular,
+  "Node.js": siNodedotjs,
+  "Spring Boot": siSpringboot,
+  "Tailwind CSS": siTailwindcss,
+  // CI/CD & Delivery
+  Jenkins: siJenkins,
+  "GitHub Actions": siGithubactions,
+  // IaC & Containers
+  Terraform: siTerraform,
+  Docker: siDocker,
+  Proxmox: siProxmox,
+  Portainer: siPortainer,
+  // Cloud & Data
+  "Google Cloud": siGooglecloud,
+  Snowflake: siSnowflake,
+  PostgreSQL: siPostgresql,
+  // AI / ML
+  "Vertex AI": siGooglecloud,
+  MCP: siModelcontextprotocol,
+  Ollama: siOllama,
+  // DevSecOps & Quality
+  Checkmarx: siCheckmarx,
+  SonarQube: siSonarqubeserver,
+  Nexus: siSonatype,
+  NexusIQ: siSonatype,
+  Selenium: siSelenium,
+  Cypress: siCypress,
+  Maven: siApachemaven,
+  // Observability
+  Splunk: siSplunk,
+  Dynatrace: siDynatrace,
+  "Sumo Logic": siSumologic,
+  Grafana: siGrafana,
+  Prometheus: siPrometheus,
+  // Platform, VCS & Networking
+  "GitHub Enterprise": siGithub,
+  Vercel: siVercel,
+  Tailscale: siTailscale,
+};
+
+// Relative luminance (0–1) of a #rrggbb brand color, for legibility decisions.
+function luminance(hex: string): number {
+  const v = parseInt(hex, 16);
+  const r = (v >> 16) & 0xff;
+  const g = (v >> 8) & 0xff;
+  const b = v & 0xff;
+  return (0.2126 * r + 0.7152 * g + 0.4114 * b) / 255;
+}
+
+interface SkillBadgeProps {
+  name: string;
+}
+
+/**
+ * A single skill pill. Renders the brand logo when one is known, otherwise the
+ * bare label. Very dark / very light logos fall back to `currentColor` so they
+ * stay legible against both the light and dark pill backgrounds.
+ */
+export function SkillBadge({ name }: SkillBadgeProps) {
+  const icon = NAME_TO_ICON[name];
+  const lum = icon ? luminance(icon.hex) : 0;
+  const useBrandColor = icon ? lum > 0.22 && lum < 0.92 : false;
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm px-3 py-1 dark:bg-zinc-800 bg-zinc-200 rounded">
+      {icon && (
+        <svg
+          role="img"
+          viewBox="0 0 24 24"
+          width={14}
+          height={14}
+          aria-hidden="true"
+          className="shrink-0"
+          fill={useBrandColor ? `#${icon.hex}` : "currentColor"}
+        >
+          <path d={icon.path} />
+        </svg>
+      )}
+      {name}
+    </span>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-github-calendar": "^5.0.5",
-        "recharts": "^2.6.2"
+        "recharts": "^2.6.2",
+        "simple-icons": "^16.23.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -7078,6 +7079,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/simple-icons": {
+      "version": "16.23.0",
+      "resolved": "https://registry.npmjs.org/simple-icons/-/simple-icons-16.23.0.tgz",
+      "integrity": "sha512-08MaTpxj9zGYUIe38tfELYkaHiGE1YgbrbXmTBf+GPxi5mEqLSORQqOXrP0QKPdaFuzEDSmW5o4xkbLlFhmdCw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/simple-icons"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/simple-icons"
+        }
+      ],
+      "license": "CC0-1.0",
+      "engines": {
+        "node": ">=0.12.18"
       }
     },
     "node_modules/simple-swizzle": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-github-calendar": "^5.0.5",
-    "recharts": "^2.6.2"
+    "recharts": "^2.6.2",
+    "simple-icons": "^16.23.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -131,36 +131,72 @@ leadership:
     role: Member
     description: Serve on the CCSU Computer Science Industry Advisory Board.
 skills:
-  - category: CI/CD
+  - category: Languages
+    items:
+      - TypeScript
+      - JavaScript
+      - Java
+      - C# / .NET
+      - SQL
+      - Python
+      - Bash
+  - category: Frameworks & UI
+    items:
+      - React
+      - Next.js
+      - Angular
+      - Node.js
+      - Spring Boot
+      - Tailwind CSS
+  - category: CI/CD & Delivery
     items:
       - Jenkins
       - GitHub Actions
       - Harness
       - AWS CodePipeline
-      - uDeploy
-  - category: DevSecOps
+      - UrbanCode Deploy
+  - category: IaC & Containers
+    items:
+      - Terraform
+      - Docker
+      - Proxmox
+      - Portainer
+  - category: Cloud & Data
+    items:
+      - AWS
+      - Google Cloud
+      - DynamoDB
+      - Snowflake
+      - Oracle
+      - PostgreSQL
+  - category: AI / ML
+    items:
+      - Vertex AI
+      - MCP
+      - Ollama
+      - Open WebUI
+  - category: DevSecOps & Quality
     items:
       - Checkmarx
       - SonarQube
-      - NexusIQ
-  - category: Artifact & Quality
-    items:
       - Nexus
+      - NexusIQ
+      - Playwright
+      - Selenium
+      - Cypress
+      - Maven
   - category: Observability
     items:
       - Splunk
       - Dynatrace
-  - category: Cloud & Data
-    items:
-      - AWS
-      - DynamoDB
-      - Snowflake
-  - category: Platform / VCS
+      - Sumo Logic
+      - Grafana
+      - Prometheus
+  - category: Platform, VCS & Networking
     items:
       - GitHub Enterprise
-  - category: AI
-    items:
-      - MCP
+      - Vercel
+      - Tailscale
 education:
   - institution: Central Connecticut State University
     degree: Bachelor of Science


### PR DESCRIPTION
## Summary
Grows the resume **Skills** section from **16 badges / 7 categories** to **48 badges / 9 categories**, now rendered with **tech brand logos**.

New badges are sourced from:
- **Experience bullets that were never badged** — Terraform, Google Cloud, Vertex AI, Docker, Java, .NET, Angular, Oracle, Playwright, Selenium, Cypress, Maven, Sumo Logic, Node.js, Spring Boot
- **Homelab + this-site stack** — Next.js, React, TypeScript, Tailwind, Vercel, PostgreSQL, Proxmox, Portainer, Grafana, Prometheus, Ollama, Tailscale, Python, Bash

Categories: Languages · Frameworks & UI · CI/CD & Delivery · IaC & Containers · Cloud & Data · AI/ML · DevSecOps & Quality · Observability · Platform, VCS & Networking.

## How it works
- New `components/skill-badge.tsx` maps each skill name to a [Simple Icons](https://simpleicons.org) brand logo.
- Brand color by default; **near-black logos fall back to `currentColor`** so they stay legible in dark mode (e.g. Next.js, GitHub, Vercel).
- Names with no matching icon (AWS, DynamoDB, Oracle, Harness, UrbanCode Deploy, Playwright, Open WebUI, SQL) render as **plain text pills** — no breakage.
- `simple-icons` added and tree-shaken via named imports.
- **PDF export and types unchanged** — `items` stay plain strings; the PDF still joins them as text.

## Verification
- `npm run build` passes — TypeScript clean, all static pages generated.
- DOM: 48 badges / 9 categories / 39 inline SVGs, no console errors.
- Computed styles confirm brand colors (Docker `#2496ED`, Tailwind `#06B6D4`) and the dark-logo → `currentColor` fallback.
- Tree-shaking verified: only used icons bundled, not the full ~3,300-icon set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)