### PR TITLE
fix(resume): condense print resume to ~2 pages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -150,12 +150,14 @@
     color: #000 !important;
   }
 
-  /* Hide site chrome and decorative / interactive bits. */
+  /* Hide site chrome, decorative/interactive bits, and detail that's
+     redundant on paper (per-job summary line + per-job tech tags). */
   header,
   footer,
   #scroll-to-top,
   [data-print-hide],
-  .job-tech {
+  .job-tech,
+  .exp-body > p {
     display: none !important;
   }
 
@@ -169,7 +171,7 @@
   .exp-body {
     max-height: none !important;
     overflow: visible !important;
-    margin-top: 0.5rem !important;
+    margin-top: 4pt !important;
   }
 
   /* Drop site gutters and top offset; use the full page width. */
@@ -179,13 +181,51 @@
     max-width: none !important;
   }
 
-  /* Tighten section spacing (mb-16 is huge on paper) and avoid mid-card breaks. */
-  main section {
-    margin-bottom: 0.75rem !important;
+  /* Compact, print-appropriate type scale (the on-screen text-5xl/3xl is huge). */
+  main p,
+  main li,
+  main time,
+  main span {
+    font-size: 9.5pt !important;
+    line-height: 1.3 !important;
   }
-  main section > div,
-  .exp-body {
-    break-inside: avoid;
+  main h1 {
+    font-size: 22pt !important;
+    line-height: 1.1 !important;
+    margin-bottom: 2pt !important;
+  }
+  main h2 {
+    font-size: 14pt !important;
+    line-height: 1.15 !important;
+    margin-bottom: 6pt !important;
+    border-bottom: 1px solid #000;
+    padding-bottom: 2pt;
+    break-after: avoid;
+  }
+  main h3 {
+    font-size: 11pt !important;
+    line-height: 1.2 !important;
+  }
+  /* Keep the role/title line under the name a touch larger than body. */
+  main .text-2xl {
+    font-size: 13pt !important;
+  }
+
+  /* Tighten vertical rhythm (mb-16 ≈ 4rem on screen). */
+  main section {
+    margin-bottom: 7pt !important;
+  }
+
+  /* Card grids collapse to 1 column in print (paper is narrower than the `md`
+     breakpoint), which wastes vertical space — force them back to 2 columns. */
+  main .grid {
+    display: grid !important;
+    grid-template-columns: 1fr 1fr !important;
+    gap: 6pt 18pt !important;
+  }
+  /* Leadership has 3 short items — one row of 3 instead of two rows of two. */
+  main .lead-grid {
+    grid-template-columns: repeat(3, 1fr) !important;
   }
 
   /* Flatten card chrome (border / fill / radius / padding / indent) to clean text. */
@@ -199,10 +239,33 @@
     box-shadow: none !important;
   }
 
+  /* Keep an individual job/card intact across a page break — but NOT the whole
+     list (that would overflow into blank pages). */
+  .space-y-10 > div,
+  .bg-secondary-bg {
+    break-inside: avoid;
+  }
+  .space-y-10 > div {
+    margin-bottom: 5pt !important;
+  }
+
+  /* Skills has 9 categories — give it 3 columns (vs the default 2) and tight
+     spacing so it doesn't overflow onto a third page. */
+  main .grid:has(> .skill-group) {
+    grid-template-columns: repeat(3, 1fr) !important;
+    gap: 5pt 14pt !important;
+  }
+  .skill-group h3 {
+    margin-bottom: 2pt !important;
+  }
+  .skill-items {
+    gap: 3pt !important;
+  }
+
   /* Skill badges: transparent pills with black ink + black logos. */
   .skill-items span {
     background: transparent !important;
-    padding-left: 0 !important;
+    padding: 1pt 6pt 1pt 0 !important;
   }
   .skill-items svg {
     fill: #000 !important;

--- a/app/globals.css
+++ b/app/globals.css
@@ -128,3 +128,92 @@
 .dark :focus-visible {
   outline-color: #a78bfa;
 }
+
+/* Print styles — make Cmd+P of /resume a clean ~2-page document.
+   The purpose-built artifact is the "Download PDF" button (components/resume-pdf.tsx);
+   this block makes the *browser print* of the live page sane and short too:
+   strips site chrome, forces every experience card open, flattens card styling
+   to plain text, goes monochrome, and caps bullets to approximate 2 pages. */
+@media print {
+  @page {
+    margin: 0.5in;
+  }
+
+  html,
+  body {
+    background: #fff !important;
+  }
+
+  /* All resume text prints solid black regardless of light/dark theme. */
+  main,
+  main * {
+    color: #000 !important;
+  }
+
+  /* Hide site chrome and decorative / interactive bits. */
+  header,
+  footer,
+  #scroll-to-top,
+  [data-print-hide],
+  .job-tech {
+    display: none !important;
+  }
+
+  /* Never print scroll-reveal elements while still in their hidden state. */
+  [data-aos] {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  /* Force every experience card fully expanded (they collapse via max-h-0). */
+  .exp-body {
+    max-height: none !important;
+    overflow: visible !important;
+    margin-top: 0.5rem !important;
+  }
+
+  /* Drop site gutters and top offset; use the full page width. */
+  main {
+    margin: 0 !important;
+    padding: 0 !important;
+    max-width: none !important;
+  }
+
+  /* Tighten section spacing (mb-16 is huge on paper) and avoid mid-card breaks. */
+  main section {
+    margin-bottom: 0.75rem !important;
+  }
+  main section > div,
+  .exp-body {
+    break-inside: avoid;
+  }
+
+  /* Flatten card chrome (border / fill / radius / padding / indent) to clean text. */
+  .bg-secondary-bg,
+  main .ml-8 {
+    background: transparent !important;
+    border: none !important;
+    border-radius: 0 !important;
+    padding: 0 !important;
+    margin-left: 0 !important;
+    box-shadow: none !important;
+  }
+
+  /* Skill badges: transparent pills with black ink + black logos. */
+  .skill-items span {
+    background: transparent !important;
+    padding-left: 0 !important;
+  }
+  .skill-items svg {
+    fill: #000 !important;
+  }
+
+  /* Condense to ~2 pages: cap bullets per role (mirrors the PDF).
+     Current/most-recent role (first card) keeps ~6; older roles keep ~3. */
+  .space-y-10 > div:first-child .exp-body ul li:nth-child(n + 7) {
+    display: none !important;
+  }
+  .space-y-10 > div:not(:first-child) .exp-body ul li:nth-child(n + 4) {
+    display: none !important;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,10 +182,14 @@
   }
 
   /* Compact, print-appropriate type scale (the on-screen text-5xl/3xl is huge). */
+  /* Body text scale — include links (`main a`) so the email in the contact row
+     matches the location span and they share a baseline (otherwise the email
+     stays at its on-screen 16px and sits misaligned). */
   main p,
   main li,
   main time,
-  main span {
+  main span,
+  main a {
     font-size: 9.5pt !important;
     line-height: 1.3 !important;
   }

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -457,7 +457,7 @@ export default function Home() {
           <h2 className="text-3xl mb-8 font-bold tracking-tight">
             Leadership &amp; Community
           </h2>
-          <div className="grid md:grid-cols-2 grid-cols-1 gap-6">
+          <div className="lead-grid grid md:grid-cols-2 grid-cols-1 gap-6">
             {leadership.map((item, index) => (
               <div
                 key={index}
@@ -478,13 +478,15 @@ export default function Home() {
         </section>
       )}
 
-      {/* Education Section */}
+      {/* Education Section — hidden in print to keep the printed resume to two
+          pages (parity with the downloaded PDF, which also omits it). */}
       {education && education.length > 0 && (
         <section
           className="mb-16"
           data-aos="fade-up"
           data-aos-duration={1000}
           data-aos-once={true}
+          data-print-hide
         >
           <h2 className="text-3xl mb-8 font-bold tracking-tight">Education</h2>
             <div className="space-y-10">

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -302,7 +302,7 @@ export default function Home() {
           {personalInfo.location && <span>{personalInfo.location}</span>}
         </div>
         {/* Social Media Links */}
-        <div className="flex flex-wrap gap-4 mb-8">
+        <div className="flex flex-wrap gap-4 mb-8" data-print-hide>
           {/* LinkedIn and GitHub */}
           {personalInfo.linkedin && (
             <a
@@ -351,7 +351,10 @@ export default function Home() {
         >
           <h2 className="text-3xl mb-8 font-bold tracking-tight">Experience</h2>
             <div className="relative">
-              <div className="absolute left-4 top-8 bottom-8 w-px -translate-x-1/2 dark:bg-zinc-700 bg-zinc-300" />
+              <div
+                className="absolute left-4 top-8 bottom-8 w-px -translate-x-1/2 dark:bg-zinc-700 bg-zinc-300"
+                data-print-hide
+              />
               <div className="space-y-10">
                 {experience.map((job, index) => (
                   <div key={index} className="relative">
@@ -360,6 +363,7 @@ export default function Home() {
                           ? "border-zinc-400 bg-secondary-color"
                           : "dark:border-zinc-400 border-zinc-400 dark:bg-zinc-900 bg-zinc-100"
                         }`}
+                      data-print-hide
                     />
                     <div
                       ref={(element) => {
@@ -404,7 +408,7 @@ export default function Home() {
                         </time>
                       </div>
                       <div
-                        className={`transition-all duration-300 overflow-hidden ${expandedIndex === index
+                        className={`exp-body transition-all duration-300 overflow-hidden ${expandedIndex === index
                           ? "max-h-[3000px] mt-4"
                           : "max-h-0"
                           }`}
@@ -422,7 +426,7 @@ export default function Home() {
                           ))}
                         </ul>
                         {job.technologies && (
-                          <div className="flex flex-wrap gap-2">
+                          <div className="job-tech flex flex-wrap gap-2">
                             {job.technologies.map((tech, i) => (
                               <span
                                 key={i}

--- a/components/resume-pdf.tsx
+++ b/components/resume-pdf.tsx
@@ -21,24 +21,24 @@ Font.register({
 
 const styles = StyleSheet.create({
   page: {
-    padding: 40,
+    padding: 30,
     fontSize: 10,
     fontFamily: "Helvetica",
-    lineHeight: 1.4,
+    lineHeight: 1.3,
   },
   header: {
-    marginBottom: 20,
-  },
-  name: {
-    fontSize: 24,
-    fontWeight: "bold",
     marginBottom: 10,
   },
-  title: {
-    fontSize: 14,
+  name: {
+    fontSize: 19,
     fontWeight: "bold",
-    marginTop: 6,
-    marginBottom: 12,
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 11,
+    fontWeight: "bold",
+    marginTop: 2,
+    marginBottom: 6,
     color: "#333",
   },
   contactInfo: {
@@ -53,19 +53,19 @@ const styles = StyleSheet.create({
   contactInfoItem: {
     fontSize: 9,
     color: "#555",
-    width: "50%",
+    marginRight: 12,
     marginBottom: 2,
   },
   section: {
-    marginBottom: 16,
+    marginBottom: 9,
   },
   sectionTitle: {
-    fontSize: 16,
+    fontSize: 12.5,
     fontWeight: "bold",
-    marginBottom: 8,
+    marginBottom: 4,
     borderBottomWidth: 1,
     borderBottomColor: "#000",
-    paddingBottom: 6,
+    paddingBottom: 2,
   },
   summaryText: {
     fontSize: 10,
@@ -73,7 +73,7 @@ const styles = StyleSheet.create({
     textAlign: "justify",
   },
   experienceItem: {
-    marginBottom: 12,
+    marginBottom: 7,
   },
   jobHeader: {
     flexDirection: "row",
@@ -98,12 +98,6 @@ const styles = StyleSheet.create({
     color: "#555",
     textAlign: "right",
   },
-  jobSummary: {
-    fontSize: 9,
-    fontStyle: "italic",
-    marginBottom: 4,
-    color: "#444",
-  },
   highlightsList: {
     marginLeft: 12,
     marginBottom: 4,
@@ -119,19 +113,6 @@ const styles = StyleSheet.create({
   },
   highlightText: {
     flex: 1,
-  },
-  techList: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    marginTop: 4,
-  },
-  techItem: {
-    fontSize: 8,
-    backgroundColor: "#f0f0f0",
-    padding: "2 6",
-    marginRight: 4,
-    marginBottom: 4,
-    borderRadius: 2,
   },
   educationItem: {
     marginBottom: 8,
@@ -155,7 +136,7 @@ const styles = StyleSheet.create({
   },
   skillCategory: {
     width: "48%",
-    marginBottom: 8,
+    marginBottom: 5,
   },
   skillCategoryTitle: {
     fontSize: 11,
@@ -279,26 +260,16 @@ const ResumePDF: React.FC<ResumePDFProps> = ({ data }) => {
                     </Text>
                   </View>
                 </View>
-                {job.summary && (
-                  <Text style={styles.jobSummary}>{job.summary}</Text>
-                )}
                 <View style={styles.highlightsList}>
-                  {job.highlights.map((highlight, i) => (
-                    <View key={i} style={styles.highlight}>
-                      <Text style={styles.bullet}>•</Text>
-                      <Text style={styles.highlightText}>{highlight}</Text>
-                    </View>
-                  ))}
-                </View>
-                {job.technologies && job.technologies.length > 0 && (
-                  <View style={styles.techList}>
-                    {job.technologies.map((tech, i) => (
-                      <Text key={i} style={styles.techItem}>
-                        {tech}
-                      </Text>
+                  {job.highlights
+                    .slice(0, index === 0 ? 6 : 3)
+                    .map((highlight, i) => (
+                      <View key={i} style={styles.highlight}>
+                        <Text style={styles.bullet}>•</Text>
+                        <Text style={styles.highlightText}>{highlight}</Text>
+                      </View>
                     ))}
-                  </View>
-                )}
+                </View>
               </View>
             ))}
           </View>


### PR DESCRIPTION
## Context

The print resume had grown to **6 pages** after the P2 content expansion (`eb22a81`) — far too long for a single-employer senior/staff profile. There are two separate print paths and both were unoptimized:

1. **Download-PDF button** → `@react-pdf/renderer` (`components/resume-pdf.tsx`), flowing all content across many pages.
2. **Browser Cmd+P of `/resume`** → no print stylesheet existed, so it printed the full interactive site, and experience cards are collapsed by default (dropping most bullets).

Both are now condensed to **~2 pages**. Content is trimmed at the *render layer* — `resume.yml` and the interactive on-screen page are unchanged.

## Changes

**PDF — `components/resume-pdf.tsx`**
- Drop redundant per-job tech tags + per-job summary lines
- Cap highlights: current role → 6, older roles → 3
- Tighten margins/padding/fonts; collapse contact to one line

**Browser print — `app/globals.css` (`@media print`) + hooks in `app/resume/page.tsx`**
- Hide header/footer/scroll-top/hero CTAs; force experience cards open
- Flatten card chrome + timeline to clean monochrome text
- Cap bullets to mirror the PDF

## Verification
- **PDF: now 2 pages** (`/Count 2`, was 6), via the real Download button path ✅
- **Browser print:** all `@media print` rules load; selectors resolve; clean black-on-white, chrome/timeline removed ✅
- **On-screen page:** unchanged (dark theme, hero, CTAs, interactive timeline intact) ✅

> Note: the PDF is pixel-controlled to exactly 2 pages; the browser-print path is clean and *approximately* 2 pages (depends on browser print scaling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)