### PR TITLE
fix(resume): restore immediate PDF download & remove mobile loading whitespace

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -84,52 +84,24 @@ export default function Home() {
 
       const blob = await pdf(<ResumePDF data={resumeData} />).toBlob();
 
-      // Open a preview tab for the PDF without auto-printing.
+      // Trigger an immediate download of the generated PDF.
       const pdfBlobUrl = URL.createObjectURL(blob);
-      const opened = window.open(pdfBlobUrl, "_blank");
+      const link = document.createElement("a");
+      link.href = pdfBlobUrl;
+      link.download = `${resumeData.personalInfo.name.replace(/\s+/g, "_")}_Resume.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
 
-      if (opened) {
-        // After the PDF loads, ensure the window scrolls to the very top
-        // and remove all default margins/padding that cause grey space on mobile
-        setTimeout(() => {
-          try {
-            opened.scrollTo(0, 0);
-            if (opened.document) {
-              const html = opened.document.documentElement;
-              const body = opened.document.body;
-
-              // Reset html element
-              html.style.margin = "0";
-              html.style.padding = "0";
-              html.style.border = "none";
-
-              // Reset body element
-              body.style.margin = "0";
-              body.style.padding = "0";
-              body.style.border = "none";
-            }
-          } catch (e) {
-            // Ignore cross-origin errors (expected on some mobile browsers)
-          }
-        }, 200);
-      } else {
-        // Fallback to download if popup was blocked
-        const link = document.createElement("a");
-        link.href = pdfBlobUrl;
-        link.download = `${resumeData.personalInfo.name.replace(/\s+/g, "_")}_Resume.pdf`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-      }
-
-      // Clean up object URL after a short delay
+      // Clean up object URL after a short delay (kept long enough for the
+      // browser to finish writing the file on slower mobile devices).
       setTimeout(() => {
         URL.revokeObjectURL(pdfBlobUrl);
       }, 60_000);
 
       // Track event
-      event("pdf_preview_opened", {
-        cta: "resume_preview",
+      event("pdf_downloaded", {
+        cta: "resume_download",
         origin: "resume",
         transport_type: "beacon",
       });
@@ -232,7 +204,7 @@ export default function Home() {
     return (
       <>
         <BreadcrumbSchema items={RESUME_BREADCRUMBS} />
-        <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20 min-h-screen">
+        <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20">
         <div className="text-center">
           <p className="text-lg dark:text-zinc-400 text-zinc-600">
             Loading resume...
@@ -247,7 +219,7 @@ export default function Home() {
     return (
       <>
         <BreadcrumbSchema items={RESUME_BREADCRUMBS} />
-        <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20 min-h-screen">
+        <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20">
         <div className="text-center">
           <p className="text-lg text-red-600 dark:text-red-400">
             {error || "Failed to load resume data"}


### PR DESCRIPTION
## Summary

Two mobile-reported bugs on the resume page.

### 1. Download button no longer downloaded the PDF immediately
Commit `44ab6d7` changed the **Download PDF** handler from an immediate download to opening the PDF in a **preview tab** via `window.open`, with the actual download only as a popup-blocked fallback. On mobile, `window.open` of a blob URL frequently opens in-page or is blocked, so users stopped getting a file.

**Fix:** restore the direct `<a download>` click so the PDF downloads immediately. Tracking reverted to `pdf_downloaded`.

### 2. "Ton of extra whitespace at the bottom" on mobile
`/resume` is a client component whose **server-rendered first paint is the loading state**, and that `<main>` carried `min-h-screen`. On a real phone `100vh` is the *tall* (address-bar-hidden) viewport, so the initial paint was a full-screen-tall empty `<main>` with just "Loading resume…" and the footer shoved a viewport down — a screen of whitespace until the YAML loads client-side.

**Fix:** drop `min-h-screen` from the loading/error states so they match the compact loaded layout (which never used it). The footer renders right under the content.

## Verification
- Download: clicking the button now creates an anchor with `download="Anthony_Brignano_Resume.pdf"` and calls `window.open` **0 times**; no console errors.
- Whitespace: SSR HTML now contains zero `min-h-screen`; loaded page still renders with the footer flush at the bottom (verified at 375×812). The loaded layout was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)