### PR TITLE
docs(experience): TSD for signature homepage "Trail" experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ import {
 } from "@heroicons/react/24/outline";
 import GitHubCalendarClient from "@/components/github-calendar-client";
 import HeroMotif from "@/components/hero-motif";
+import TrailThread from "@/components/trail-thread";
+import CountUp from "@/components/count-up";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
 import {
   socialLinks,
@@ -29,6 +31,7 @@ export default function Home() {
   return (
     <>
       <BreadcrumbSchema items={HOME_BREADCRUMBS} />
+      <TrailThread />
       <main className="max-w-7xl mx-auto md:px-16 px-6 lg:mt-32 mt-20">
         {/* Hero Section with CTAs */}
         <section className="relative overflow-hidden mb-8 md:mb-24">
@@ -59,7 +62,7 @@ export default function Home() {
                   className="flex flex-col sm:px-5 sm:first:pl-0 sm:border-l sm:first:border-l-0 dark:border-zinc-800 border-zinc-200"
                 >
                   <dd className="text-xl font-bold tracking-tight">
-                    {metric.value}
+                    <CountUp value={metric.value} />
                   </dd>
                   <dt className="text-xs dark:text-zinc-400 text-zinc-500 mt-1">
                     {metric.label}

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,72 +1,99 @@
 "use client";
 
 /**
- * THROWAWAY POC v4 — signature "Trail" experience (TSD P0 taste gate).
- * Back to the clean v1 aesthetic (user verdict: scenery/figure read childish).
- *  - abstract glowing-dot marker rides the drawn switchback trail
- *  - color wash per zone (mood), meaning carried by TYPOGRAPHY (copy/labels)
- *  - kept the clean structural wins: sticky nav + real content cards
- *  - NO scenery, NO figure. Restraint = senior.
- *  - reduced-motion -> static complete trail
+ * THROWAWAY POC v5 — signature scroll experience over REAL content.
+ * Decoupled from the mountain theme (user: "too themed").
+ *  - YOUR actual homepage sections & copy (from lib/constants.ts), unrestructured
+ *  - signature = abstract trail thread that draws on scroll (no zone labels/theme)
+ *    + scroll-reveal choreography + hero metric count-up + sticky nav + ⌘K
+ *  - trail line evolves through a cohesive cool palette (aesthetic only, not "zones")
+ *  - reduced-motion -> everything visible, trail fully drawn, no count-up
  */
 
 import { useEffect, useRef, useState } from "react";
 
-// Option 2 (expedition day) — order still open; meaning is in the words.
-const ZONES = [
-  {
-    key: "approach", sport: "Hike", label: "The approach",
-    heading: "About",
-    body: "Platform engineer who likes hard problems and clean abstractions. The work — and the mountains — both start with the approach.",
-    accent: "#6f9e6f", bg: "#0a120d",
-  },
-  {
-    key: "crux", sport: "Climb", label: "The crux",
-    heading: "The work",
-    body: "Internal developer platforms for thousands of engineers — CI/CD, DevOps intelligence, and AI-native tooling. The crux: make shipping safe and fast.",
-    accent: "#9b7cff", bg: "#120e1c",
-  },
-  {
-    key: "descent", sport: "Snowboard", label: "The descent",
-    heading: "Off the clock",
-    body: "Homelab, local-LLM routing, AI-native tooling with Claude Code — and when the screens are off, snowboarding through the woods.",
-    accent: "#6fa8d6", bg: "#0a1019",
-  },
-] as const;
+const METRICS = [
+  { value: "8,000+", label: "enterprise developers" },
+  { value: "1,000+", label: "active in 90 days" },
+  { value: "10,000+", label: "repos migrated" },
+];
+
+const ACHIEVEMENTS = [
+  { outcome: "A unified developer platform for 8,000+ engineers", skills: ["GitHub Enterprise", "Custom CLI", "IDE Extensions"] },
+  { outcome: "1,000+ engineers active in the first 90 days", skills: ["Desktop App", "CLI", "Self-service onboarding"] },
+  { outcome: "One build command, any stack — local, CI, or fully remote", skills: ["CI/CD", "Base-image registry", "Containers"] },
+  { outcome: "Real-time DevOps intelligence for engineers and AI agents", skills: ["MCP", "AWS", "DynamoDB", "Snowflake"] },
+];
+
+const NOW = [
+  { label: "Homelab", detail: "Proxmox · Docker · Tailscale" },
+  { label: "Local-LLM routing", detail: "Ollama · Open WebUI" },
+  { label: "AI-native tooling", detail: "Claude Code" },
+];
+
+const ACCENT = ["#6d8cff", "#9b7cff", "#56b6c2"]; // cohesive cool palette, aesthetic only
 
 function buildSwitchbackPath(h: number, w: number) {
-  const cx = w / 2;
-  const amp = w / 2 - 18;
-  const seg = 260;
-  const n = Math.max(6, Math.round(h / seg));
-  const step = h / n;
-  let xprev = cx;
-  let d = `M ${cx} 0`;
+  const cx = w / 2, amp = w / 2 - 18, seg = 300;
+  const n = Math.max(6, Math.round(h / seg)), step = h / n;
+  let xprev = cx, d = `M ${cx} 0`;
   for (let i = 1; i <= n; i++) {
-    const ny = i * step;
-    const x = i % 2 ? cx + amp : cx - amp;
-    const c1y = (i - 1) * step + step * 0.5;
-    const c2y = ny - step * 0.5;
-    d += ` C ${xprev} ${c1y}, ${x} ${c2y}, ${x} ${ny}`;
+    const ny = i * step, x = i % 2 ? cx + amp : cx - amp;
+    d += ` C ${xprev} ${(i - 1) * step + step * 0.5}, ${x} ${ny - step * 0.5}, ${x} ${ny}`;
     xprev = x;
   }
   return d;
 }
 
+function Metric({ value, label }: { value: string; label: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [disp, setDisp] = useState(value);
+  useEffect(() => {
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reduced) return;
+    const num = parseInt(value.replace(/[^0-9]/g, ""), 10);
+    const suffix = value.replace(/[0-9,]/g, "");
+    setDisp("0" + suffix);
+    const el = ref.current;
+    if (!el || !num) return;
+    let done = false;
+    const io = new IntersectionObserver((entries) => {
+      if (!entries[0].isIntersecting || done) return;
+      done = true;
+      const start = performance.now(), dur = 1200;
+      const tick = (t: number) => {
+        const p = Math.min((t - start) / dur, 1);
+        const eased = 1 - Math.pow(1 - p, 3);
+        setDisp(Math.round(num * eased).toLocaleString() + suffix);
+        if (p < 1) requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
+    }, { threshold: 0.6 });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [value]);
+  return (
+    <div className="m-metric">
+      <span ref={ref} className="m-num">{disp}</span>
+      <span className="m-label">{label}</span>
+    </div>
+  );
+}
+
 export default function PocTrail() {
   const pathRef = useRef<SVGPathElement>(null);
   const markerRef = useRef<SVGGElement>(null);
-  const [dims, setDims] = useState({ h: 0, w: 320 });
+  const rootRef = useRef<HTMLDivElement>(null);
+  const [dims, setDims] = useState({ h: 0, w: 300 });
   const [d, setD] = useState("");
-  const [zone, setZone] = useState(0);
+  const [accent, setAccent] = useState(ACCENT[0]);
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
-    setReduced(mq.matches);
+    setReduced(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
     const measure = () => {
       const h = document.documentElement.scrollHeight;
-      const w = Math.min(Math.max(window.innerWidth * 0.5, 220), 380);
+      const w = Math.min(Math.max(window.innerWidth * 0.45, 200), 340);
       setDims({ h, w });
       setD(buildSwitchbackPath(h, w));
     };
@@ -75,6 +102,20 @@ export default function PocTrail() {
     return () => window.removeEventListener("resize", measure);
   }, []);
 
+  // scroll-reveal choreography
+  useEffect(() => {
+    if (reduced) {
+      rootRef.current?.querySelectorAll(".reveal").forEach((e) => e.classList.add("in"));
+      return;
+    }
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((e) => { if (e.isIntersecting) e.target.classList.add("in"); });
+    }, { threshold: 0.18 });
+    rootRef.current?.querySelectorAll(".reveal").forEach((e) => io.observe(e));
+    return () => io.disconnect();
+  }, [reduced, d]);
+
+  // trail draw + marker + accent evolution
   useEffect(() => {
     const path = pathRef.current;
     if (!path || !d) return;
@@ -91,10 +132,9 @@ export default function PocTrail() {
       const pt = path.getPointAtLength((reduced ? 1 : p) * total);
       if (markerRef.current) {
         markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
-        markerRef.current.style.opacity = "1";
+        markerRef.current.style.opacity = reduced ? "0" : "1";
       }
-      setZone(p < 1 / 3 ? 0 : p < 2 / 3 ? 1 : 2);
-      document.documentElement.style.setProperty("--p", `${p}`);
+      setAccent(ACCENT[p < 0.4 ? 0 : p < 0.72 ? 1 : 2]);
     };
     const onScroll = () => { if (!raf) raf = requestAnimationFrame(update); };
     update();
@@ -102,54 +142,96 @@ export default function PocTrail() {
     return () => { window.removeEventListener("scroll", onScroll); if (raf) cancelAnimationFrame(raf); };
   }, [d, reduced]);
 
-  const z = ZONES[zone];
-
   return (
-    <div className="poc-root">
+    <div className="poc-root" ref={rootRef}>
       <style>{css}</style>
 
       <nav className="poc-nav" aria-label="Primary">
         <a className="poc-mono" href="#">A<span>|</span>B</a>
         <div className="poc-links">
-          <a href="#">About</a><a href="#">Work</a><a href="#">Coding</a>
-          <a href="#">Blog</a><a href="#">Contact</a>
+          <a href="#about">About</a><a href="#work">Work</a><a href="#">Coding</a>
+          <a href="#">Blog</a><a href="#contact">Contact</a>
           <span className="poc-kbd">⌘K</span>
         </div>
       </nav>
 
-      <div className="poc-bg" style={{ background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)` }} aria-hidden />
+      <div className="poc-bg" aria-hidden />
 
       <svg className="poc-trail" width={dims.w} height={dims.h} viewBox={`0 0 ${dims.w} ${dims.h}`} fill="none" aria-hidden>
-        <path d={d} stroke="#ffffff" strokeOpacity={0.06} strokeWidth={2.5} />
-        <path ref={pathRef} d={d} stroke={z.accent} strokeWidth={3} strokeLinecap="round" style={{ transition: "stroke 600ms ease" }} />
+        <path d={d} stroke="#ffffff" strokeOpacity={0.055} strokeWidth={2.5} />
+        <path ref={pathRef} d={d} stroke={accent} strokeWidth={2.5} strokeLinecap="round" style={{ transition: "stroke 800ms ease" }} />
         <g ref={markerRef} style={{ opacity: 0 }}>
-          <circle r={11} fill={z.accent} fillOpacity={0.2} />
-          <circle r={5} fill={z.accent} />
+          <circle r={10} fill={accent} fillOpacity={0.18} />
+          <circle r={4.5} fill={accent} />
         </g>
       </svg>
 
       <div className="poc-content">
+        {/* HERO */}
         <section className="poc-hero">
-          <p className="poc-eyebrow">Trailhead</p>
-          <h1>I build the platforms<br />engineers ship on.</h1>
-          <p className="poc-lede">Walk the approach. Climb the crux. Ride it out.</p>
-          <p className="poc-scrollcue">↓ scroll</p>
+          <p className="poc-eyebrow reveal">Anthony Brignano</p>
+          <h1 className="reveal">I build the platforms<br />engineers ship on.</h1>
+          <p className="poc-lede reveal">Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes onboarding self-service and delivery faster and safer.</p>
+          <div className="poc-metrics reveal">
+            {METRICS.map((m) => <Metric key={m.label} value={m.value} label={m.label} />)}
+          </div>
+          <div className="poc-cta reveal">
+            <a className="btn primary" style={{ background: accent }} href="#">Résumé</a>
+            <a className="btn ghost" href="#">Coding activity</a>
+          </div>
         </section>
 
-        {ZONES.map((zn, i) => (
-          <section key={zn.key} className="poc-zone">
-            <div className="poc-card" style={{ borderColor: zn.accent }}>
-              <p className="poc-eyebrow" style={{ color: zn.accent }}>{String(i + 1).padStart(2, "0")} · {zn.sport} — {zn.label}</p>
-              <h2>{zn.heading}</h2>
-              <p>{zn.body}</p>
-            </div>
-          </section>
-        ))}
+        {/* ABOUT */}
+        <section id="about" className="poc-sec">
+          <h2 className="reveal">About</h2>
+          <p className="poc-prose reveal">I lead the internal developer platform thousands of engineers build on — chasing clean abstractions, fast feedback loops, and making the right thing the easy thing. Off the clock: homelab tinkering, local-LLM experiments, and time on rock, snow, and trail.</p>
+        </section>
 
-        <section className="poc-summit">
-          <p className="poc-eyebrow" style={{ color: ZONES[1].accent }}>The ride out</p>
-          <h2>Let&apos;s build something.</h2>
-          <p className="poc-lede">Every summit is just the next trailhead.</p>
+        {/* WORK / HIGHLIGHTS */}
+        <section id="work" className="poc-sec">
+          <h2 className="reveal">Highlights</h2>
+          <div className="poc-grid">
+            {ACHIEVEMENTS.map((a, i) => (
+              <div className="poc-ach reveal" key={i} style={{ transitionDelay: `${i * 70}ms` }}>
+                <p className="ach-outcome">{a.outcome}</p>
+                <div className="ach-skills">{a.skills.map((s) => <span key={s} className="pill">{s}</span>)}</div>
+              </div>
+            ))}
+          </div>
+          <div className="poc-now reveal">
+            <span className="now-eyebrow">Now building</span>
+            {NOW.map((n) => (
+              <span key={n.label} className="now-item"><strong>{n.label}</strong> {n.detail}</span>
+            ))}
+          </div>
+        </section>
+
+        {/* CURRENT ROLE */}
+        <section className="poc-sec">
+          <h2 className="reveal">Current role</h2>
+          <ul className="poc-bullets">
+            <li className="reveal">A single pane of glass for 8,000+ engineers — custom CLI, desktop app, and IDE extensions.</li>
+            <li className="reveal">&ldquo;One build command, any stack&rdquo; — context-aware builds that run the same locally, in CI, or fully remote.</li>
+            <li className="reveal">Real-time DevOps intelligence streaming telemetry into AWS, DynamoDB, and Snowflake; native AI tooling via MCP.</li>
+            <li className="reveal">Operating the enterprise CI/CD + DevSecOps toolchain end to end across thousands of pipelines.</li>
+          </ul>
+        </section>
+
+        {/* OPEN SOURCE */}
+        <section className="poc-sec">
+          <h2 className="reveal">Open-source activity</h2>
+          <div className="poc-cal reveal" aria-hidden>
+            {Array.from({ length: 120 }).map((_, i) => (
+              <span key={i} className="cell" style={{ opacity: 0.12 + ((i * 37) % 7) / 9 }} />
+            ))}
+          </div>
+        </section>
+
+        {/* CONTACT */}
+        <section id="contact" className="poc-contact">
+          <h2 className="reveal">Let&apos;s build something.</h2>
+          <p className="poc-lede reveal">Always up for a good problem.</p>
+          <a className="btn primary reveal" style={{ background: accent }} href="#">hi@brignano.io</a>
         </section>
       </div>
     </div>
@@ -159,7 +241,7 @@ export default function PocTrail() {
 const css = `
 header, footer { display: none !important; }
 .poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
-.poc-bg { position: fixed; inset: 0; z-index: 0; transition: background 700ms ease; }
+.poc-bg { position: fixed; inset: 0; z-index: 0; background: radial-gradient(120% 80% at 50% -10%, #0c0d13 0%, #050609 70%); }
 
 .poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.5); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
 .poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
@@ -169,20 +251,47 @@ header, footer { display: none !important; }
 .poc-links a:hover { color: #fff; }
 .poc-kbd { font-size: 11px; color: #9a9aa6; border: 1px solid rgba(255,255,255,.15); border-radius: 6px; padding: 3px 7px; }
 
-.poc-content { position: relative; z-index: 2; max-width: 720px; margin: 0 auto; padding: 0 24px; }
 .poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
-.poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
+.poc-content { position: relative; z-index: 2; max-width: 880px; margin: 0 auto; padding: 0 24px; }
+
+.reveal { opacity: 0; transform: translateY(22px); transition: opacity .7s cubic-bezier(.2,.7,.2,1), transform .7s cubic-bezier(.2,.7,.2,1); }
+.reveal.in { opacity: 1; transform: none; }
+
 .poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .85; margin: 0 0 16px; }
+.poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
-.poc-lede { font-size: clamp(16px, 2.2vw, 20px); color: #c8c8d0; max-width: 40ch; }
-.poc-scrollcue { margin-top: 48px; font-size: 13px; letter-spacing: .3em; text-transform: uppercase; opacity: .5; animation: cue 1.8s ease-in-out infinite; }
-@keyframes cue { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
-.poc-zone { min-height: 100vh; display: flex; align-items: center; }
-.poc-zone:nth-child(odd) .poc-card { margin-left: auto; }
-.poc-card { background: rgba(12,14,20,.55); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
-.poc-card h2 { font-size: clamp(26px, 4vw, 38px); margin: 0 0 12px; font-weight: 600; letter-spacing: -.01em; }
-.poc-card p { margin: 0; color: #c2c2cc; line-height: 1.5; }
-.poc-summit { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
-.poc-summit h2 { font-size: clamp(34px, 6vw, 60px); margin: 0 0 16px; font-weight: 600; letter-spacing: -.02em; }
-@media (prefers-reduced-motion: reduce) { .poc-scrollcue { animation: none; } }
+.poc-lede { font-size: clamp(16px, 2.1vw, 20px); color: #c8c8d0; max-width: 54ch; line-height: 1.5; }
+.poc-metrics { display: flex; gap: 40px; margin: 36px 0 32px; flex-wrap: wrap; }
+.m-metric { display: flex; flex-direction: column; }
+.m-num { font-size: clamp(26px, 4vw, 38px); font-weight: 600; letter-spacing: -.01em; }
+.m-label { font-size: 13px; color: #9a9aa6; margin-top: 4px; }
+.poc-cta { display: flex; gap: 14px; flex-wrap: wrap; }
+.btn { display: inline-block; padding: 11px 20px; border-radius: 10px; font-size: 14px; font-weight: 500; text-decoration: none; transition: transform .15s ease, filter .15s ease; }
+.btn:hover { transform: translateY(-2px); }
+.btn.primary { color: #0a0a0f; }
+.btn.primary:hover { filter: brightness(1.08); }
+.btn.ghost { color: #e6e6ea; border: 1px solid rgba(255,255,255,.2); }
+
+.poc-sec { padding: 12vh 0; }
+.poc-sec h2 { font-size: clamp(24px, 3.5vw, 34px); font-weight: 600; letter-spacing: -.01em; margin: 0 0 24px; }
+.poc-prose { font-size: clamp(16px, 2vw, 19px); color: #c8c8d0; max-width: 60ch; line-height: 1.6; }
+.poc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+.poc-ach { background: rgba(14,16,22,.55); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; backdrop-filter: blur(6px); }
+.ach-outcome { margin: 0 0 14px; font-size: 16px; line-height: 1.4; }
+.ach-skills { display: flex; flex-wrap: wrap; gap: 7px; }
+.pill { font-size: 11.5px; color: #b9b9c4; border: 1px solid rgba(255,255,255,.14); border-radius: 999px; padding: 3px 10px; }
+.poc-now { display: flex; flex-wrap: wrap; align-items: center; gap: 18px; margin-top: 22px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,.08); }
+.now-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .12em; font-size: 11px; color: #8a8a96; }
+.now-item { font-size: 13.5px; color: #b9b9c4; }
+.now-item strong { color: #ededf2; font-weight: 600; }
+.poc-bullets { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 16px; max-width: 64ch; }
+.poc-bullets li { position: relative; padding-left: 20px; color: #c8c8d0; line-height: 1.5; }
+.poc-bullets li::before { content: "—"; position: absolute; left: 0; color: #7b7b88; }
+.poc-cal { display: grid; grid-template-columns: repeat(20, 1fr); gap: 5px; max-width: 540px; }
+.cell { aspect-ratio: 1; border-radius: 3px; background: #8b9bff; }
+.poc-contact { min-height: 80vh; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; }
+.poc-contact h2 { font-size: clamp(34px, 6vw, 58px); font-weight: 600; letter-spacing: -.02em; margin: 0 0 14px; }
+.poc-contact .btn { margin-top: 22px; }
+@media (max-width: 640px) { .poc-grid { grid-template-columns: 1fr; } }
+@media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } }
 `;

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+/**
+ * THROWAWAY POC — signature "Trail" experience (TSD P0 taste gate).
+ * Not production code. Self-contained on purpose so it's easy to delete.
+ * Demonstrates: scroll-drawn switchback trail (SVG stroke-dashoffset),
+ * a marker that rides the path, three altitude zones with ambient hue
+ * shifts, waypoints, and reduced-motion -> static complete trail.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+// Option 1 (Ascent): approach -> slopes -> summit. Climb = apex.
+const ZONES = [
+  {
+    key: "approach",
+    sport: "Hike",
+    label: "The approach",
+    sub: "Foundations — showing up, the grind before the reward.",
+    accent: "#6f9e6f", // moss
+    bg: "#0a120d",
+  },
+  {
+    key: "slopes",
+    sport: "Snowboard",
+    label: "The slopes",
+    sub: "Momentum — flow, speed, reading the terrain.",
+    accent: "#6fa8d6", // ice
+    bg: "#0a1019",
+  },
+  {
+    key: "summit",
+    sport: "Climb",
+    label: "The summit",
+    sub: "The crux — focus, commitment, the move that matters.",
+    accent: "#9b7cff", // violet (summit accent)
+    bg: "#120e1c",
+  },
+] as const;
+
+function buildSwitchbackPath(h: number, w: number) {
+  const cx = w / 2;
+  const amp = w / 2 - 18;
+  const seg = 260;
+  const n = Math.max(6, Math.round(h / seg));
+  const step = h / n;
+  let xprev = cx;
+  let d = `M ${cx} 0`;
+  for (let i = 1; i <= n; i++) {
+    const ny = i * step;
+    const x = i % 2 ? cx + amp : cx - amp;
+    const c1y = (i - 1) * step + step * 0.5;
+    const c2y = ny - step * 0.5;
+    d += ` C ${xprev} ${c1y}, ${x} ${c2y}, ${x} ${ny}`;
+    xprev = x;
+  }
+  return d;
+}
+
+export default function PocTrail() {
+  const pathRef = useRef<SVGPathElement>(null);
+  const markerRef = useRef<SVGGElement>(null);
+  const [dims, setDims] = useState({ h: 0, w: 320 });
+  const [d, setD] = useState("");
+  const [zone, setZone] = useState(0);
+  const [reduced, setReduced] = useState(false);
+
+  // Measure + build path
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReduced(mq.matches);
+    const measure = () => {
+      const h = document.documentElement.scrollHeight;
+      const w = Math.min(Math.max(window.innerWidth * 0.5, 220), 380);
+      setDims({ h, w });
+      setD(buildSwitchbackPath(h, w));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, []);
+
+  // Drive draw + marker + zone on scroll
+  useEffect(() => {
+    const path = pathRef.current;
+    if (!path || !d) return;
+    const total = path.getTotalLength();
+    path.style.strokeDasharray = `${total}`;
+    path.style.strokeDashoffset = reduced ? "0" : `${total}`;
+
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      const el = document.scrollingElement || document.documentElement;
+      const max = el.scrollHeight - el.clientHeight;
+      const p = max > 0 ? Math.min(Math.max(el.scrollTop / max, 0), 1) : 0;
+      if (!reduced) path.style.strokeDashoffset = `${total * (1 - p)}`;
+      const pt = path.getPointAtLength(p * total);
+      if (markerRef.current) {
+        markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
+        markerRef.current.style.opacity = reduced ? "0" : "1";
+      }
+      const z = p < 1 / 3 ? 0 : p < 2 / 3 ? 1 : 2;
+      setZone(z);
+      document.documentElement.style.setProperty("--p", `${p}`);
+    };
+    const onScroll = () => {
+      if (!raf) raf = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [d, reduced]);
+
+  const z = ZONES[zone];
+
+  return (
+    <div className="poc-root">
+      <style>{css}</style>
+
+      {/* Ambient background that shifts per zone */}
+      <div
+        className="poc-bg"
+        style={{
+          background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)`,
+        }}
+        aria-hidden
+      />
+
+      {/* The trail */}
+      <svg
+        className="poc-trail"
+        width={dims.w}
+        height={dims.h}
+        viewBox={`0 0 ${dims.w} ${dims.h}`}
+        fill="none"
+        aria-hidden
+      >
+        {/* faint full path (the trail ahead) */}
+        <path d={d} stroke="#ffffff" strokeOpacity={0.06} strokeWidth={2.5} />
+        {/* drawn path (where you've been) */}
+        <path
+          ref={pathRef}
+          d={d}
+          stroke={z.accent}
+          strokeWidth={3}
+          strokeLinecap="round"
+          style={{ transition: "stroke 600ms ease" }}
+        />
+        {/* moving marker */}
+        <g ref={markerRef} style={{ transition: "opacity 300ms" }}>
+          <circle r={11} fill={z.accent} fillOpacity={0.2} />
+          <circle r={5} fill={z.accent} />
+        </g>
+      </svg>
+
+      {/* Content */}
+      <div className="poc-content">
+        <section className="poc-hero">
+          <p className="poc-eyebrow">Trailhead</p>
+          <h1>
+            I build the platforms
+            <br />
+            engineers ship on.
+          </h1>
+          <p className="poc-lede">
+            Every route starts at the trailhead. Scroll to follow the climb.
+          </p>
+          <p className="poc-scrollcue">↓ scroll</p>
+        </section>
+
+        {ZONES.map((zone, i) => (
+          <section key={zone.key} className="poc-zone">
+            <div className="poc-card" style={{ borderColor: zone.accent }}>
+              <p className="poc-eyebrow" style={{ color: zone.accent }}>
+                {String(i + 1).padStart(2, "0")} · {zone.sport}
+              </p>
+              <h2>{zone.label}</h2>
+              <p>{zone.sub}</p>
+            </div>
+          </section>
+        ))}
+
+        <section className="poc-summit">
+          <p className="poc-eyebrow" style={{ color: ZONES[2].accent }}>
+            The peak
+          </p>
+          <h2>Let&apos;s build something.</h2>
+          <p className="poc-lede">The summit is just the next trailhead.</p>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+const css = `
+.poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
+.poc-bg { position: fixed; inset: 0; z-index: 0; transition: background 700ms ease; }
+.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
+.poc-content { position: relative; z-index: 2; max-width: 720px; margin: 0 auto; padding: 0 24px; }
+.poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
+.poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .8; margin: 0 0 16px; }
+.poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
+.poc-lede { font-size: clamp(16px, 2.2vw, 20px); color: #c8c8d0; max-width: 38ch; }
+.poc-scrollcue { margin-top: 48px; font-size: 13px; letter-spacing: .3em; text-transform: uppercase; opacity: .5; animation: bob 1.8s ease-in-out infinite; }
+@keyframes bob { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
+.poc-zone { min-height: 100vh; display: flex; align-items: center; }
+.poc-zone:nth-child(odd) .poc-card { margin-left: auto; }
+.poc-card { background: rgba(12,14,20,.55); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+.poc-card h2 { font-size: clamp(26px, 4vw, 38px); margin: 0 0 12px; font-weight: 600; letter-spacing: -.01em; }
+.poc-card p { margin: 0; color: #c2c2cc; line-height: 1.5; }
+.poc-summit { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
+.poc-summit h2 { font-size: clamp(34px, 6vw, 60px); margin: 0 0 16px; font-weight: 600; letter-spacing: -.02em; }
+@media (prefers-reduced-motion: reduce) { .poc-scrollcue { animation: none; } }
+`;

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 /**
- * THROWAWAY POC v2 — signature "Trail" experience (TSD P0 taste gate).
- * Not production code. Demonstrates the FULL layout:
- *  - sticky translucent nav (where real nav lives)
- *  - real-content scaffolding sitting in cards along the trail
- *  - a pose-swap FIGURE that rides the path: hike -> climb -> snowboard
- *  - Option 2 ordering (walk the approach, climb the crux, ride the descent)
+ * THROWAWAY POC v3 — signature "Trail" experience (TSD P0 taste gate).
+ * Not production code. v3 adds:
+ *  - per-zone BIOME scenery (flat silhouette horizons) + color wash together
+ *  - distinct figure PROPS: hiker (hat/pack/camera), climber (helmet/harness/rope),
+ *    snowboarder (board/goggles)
+ *  - figure pose stays tied to ZONE (not scroll direction) — intentional.
  *  - reduced-motion -> static complete trail, no idle bob
  */
 
@@ -15,36 +15,38 @@ import { useEffect, useRef, useState } from "react";
 // Option 2 (expedition day): approach -> crux -> descent.
 const ZONES = [
   {
-    key: "approach",
-    sport: "Hike",
-    label: "The approach",
-    sub: "Foundations — showing up, the long walk in before anything happens.",
+    key: "approach", sport: "Hike", label: "The approach",
     heading: "About",
     body: "Platform engineer who likes hard problems and clean abstractions. The work — and the mountains — both start with the approach.",
-    accent: "#6f9e6f",
-    bg: "#0a120d",
+    accent: "#6f9e6f", bg: "#0a120d", sky: "#0f1d14",
   },
   {
-    key: "crux",
-    sport: "Climb",
-    label: "The crux",
-    sub: "The hardest move — focus, commitment, the part that matters.",
+    key: "crux", sport: "Climb", label: "The crux",
     heading: "The work",
     body: "Internal developer platforms for thousands of engineers — CI/CD, DevOps intelligence, and AI-native tooling. The crux: make shipping safe and fast.",
-    accent: "#9b7cff", // violet — the summit/crux color
-    bg: "#120e1c",
+    accent: "#9b7cff", bg: "#120e1c", sky: "#1b1430",
   },
   {
-    key: "descent",
-    sport: "Snowboard",
-    label: "The descent",
-    sub: "Flow — the reward, reading the terrain, the ride out.",
+    key: "descent", sport: "Snowboard", label: "The descent",
     heading: "Off the clock",
     body: "Homelab, local-LLM routing, AI-native tooling with Claude Code — and when the screens are off, snowboarding through the woods.",
-    accent: "#6fa8d6",
-    bg: "#0a1019",
+    accent: "#6fa8d6", bg: "#0a1019", sky: "#101b2b",
   },
 ] as const;
+
+// Flat silhouette horizons (viewBox 1440x400, stretched full-width, bottom-anchored)
+const SCENERY = {
+  far: "M0 400 L0 230 L260 130 L520 210 L780 110 L1040 200 L1300 120 L1440 180 L1440 400 Z",
+  // forest: low hill + jagged treeline
+  approach:
+    "M0 400 L0 320 L40 270 L70 312 L110 255 L150 306 L195 250 L235 300 L280 246 L320 300 L370 256 L410 305 L460 260 L500 305 L555 250 L600 300 L650 260 L700 305 L760 250 L810 300 L860 258 L910 302 L965 250 L1010 300 L1065 258 L1110 302 L1165 252 L1210 300 L1265 258 L1310 300 L1365 255 L1410 300 L1440 282 L1440 400 Z",
+  // rock: tall sharp alpine spires
+  crux:
+    "M0 400 L0 260 L120 90 L200 205 L300 60 L400 195 L520 42 L640 205 L760 80 L880 210 L1000 70 L1120 205 L1240 100 L1360 210 L1440 150 L1440 400 Z",
+  // snow: smooth rolling ridge
+  descent:
+    "M0 400 L0 300 C 240 250, 420 232, 620 262 C 760 282, 820 182, 980 202 C 1140 222, 1260 300, 1440 290 L1440 400 Z",
+};
 
 function buildSwitchbackPath(h: number, w: number) {
   const cx = w / 2;
@@ -65,53 +67,63 @@ function buildSwitchbackPath(h: number, w: number) {
   return d;
 }
 
-// --- pose-swap line-art figures (rough POC art; refine later) ---
 function Figure({ zone, color }: { zone: number; color: string }) {
-  const s = {
-    stroke: color,
-    strokeWidth: 1.6,
-    strokeLinecap: "round" as const,
-    strokeLinejoin: "round" as const,
-    fill: "none",
-  };
+  const s = { stroke: color, strokeWidth: 1.5, strokeLinecap: "round" as const, strokeLinejoin: "round" as const, fill: "none" };
+  const cap = { fill: color, stroke: "none" };
   if (zone === 0) {
-    // hiker: walking with a trekking pole
+    // hiker: hat, daypack, camera, trekking pole
     return (
       <g {...s}>
-        <circle cx={0} cy={-12} r={2.6} fill={color} stroke="none" />
-        <path d="M0 -9 L0 0" />
+        <circle cx={0} cy={-11} r={2.3} {...cap} />
+        <path d="M-4 -13 L4 -13" /> {/* hat brim */}
+        <path d="M-2.5 -13 Q0 -17 2.5 -13" {...cap} /> {/* hat crown */}
+        <rect x={-6.5} y={-9} width={4} height={8} rx={1.5} fill={color} fillOpacity={0.5} stroke="none" /> {/* pack */}
+        <rect x={1.2} y={-5} width={3} height={2.3} rx={0.5} /> {/* camera */}
+        <path d="M0 -8 L0 0" />
         <path d="M0 0 L-4 7" />
         <path d="M0 0 L4 6" />
         <path d="M0 -6 L5 -3" />
-        <path d="M5 -3 L6 8" />
+        <path d="M5 -3 L6 8" /> {/* pole */}
       </g>
     );
   }
   if (zone === 1) {
-    // climber: reaching up on a wall
+    // climber: helmet, harness, trailing rope, reaching pose, rock edge
     return (
       <g {...s}>
-        <path d="M9 -16 L9 9" strokeOpacity={0.35} />
-        <circle cx={2} cy={-12} r={2.6} fill={color} stroke="none" />
-        <path d="M2 -9 L0 0" />
-        <path d="M2 -8 L7 -15" />
-        <path d="M0 -6 L-4 -3" />
-        <path d="M0 0 L-3 8" />
-        <path d="M0 0 L4 6" />
+        <path d="M9 -16 L9 10" strokeOpacity={0.3} /> {/* rock edge */}
+        <circle cx={0} cy={-11} r={2.3} {...cap} />
+        <path d="M-3 -11 Q0 -15.5 3 -11 Z" {...cap} /> {/* helmet */}
+        <path d="M0 -8 L-1 0" />
+        <path d="M0 -7 L5 -14" /> {/* reaching arm */}
+        <path d="M-1 -5 L-5 -2" /> {/* low arm */}
+        <rect x={-3.5} y={-1} width={7} height={2} rx={0.7} fill={color} fillOpacity={0.6} stroke="none" /> {/* harness */}
+        <path d="M-1 0 L-4 8" />
+        <path d="M-1 0 L3 6" />
+        <path d="M0 1 C 6 6, -2 13, 4 21" strokeOpacity={0.7} /> {/* rope */}
       </g>
     );
   }
-  // snowboarder: crouched on a board
+  // snowboarder: board, goggles, arms out
   return (
     <g {...s}>
-      <path d="M-9 8 L9 6" strokeWidth={2.2} />
+      <path d="M-9 8 L9 6" strokeWidth={2.4} />
       <path d="M-3 7 L-1 0" />
       <path d="M4 6 L1 0" />
       <path d="M0 0 L1 -7" />
-      <circle cx={1} cy={-10} r={2.6} fill={color} stroke="none" />
+      <circle cx={1} cy={-10} r={2.3} {...cap} />
+      <path d="M-1 -10.5 L3.2 -10.7" strokeWidth={1.4} /> {/* goggles */}
       <path d="M0 -4 L-7 -6" />
       <path d="M0 -4 L8 -3" />
     </g>
+  );
+}
+
+function Horizon({ d, fill, opacity, z }: { d: string; fill: string; opacity: number; z: number }) {
+  return (
+    <svg className="poc-horizon" viewBox="0 0 1440 400" preserveAspectRatio="none" aria-hidden style={{ zIndex: z }}>
+      <path d={d} fill={fill} style={{ transition: "opacity 700ms ease" }} opacity={opacity} />
+    </svg>
   );
 }
 
@@ -143,7 +155,6 @@ export default function PocTrail() {
     const total = path.getTotalLength();
     path.style.strokeDasharray = `${total}`;
     path.style.strokeDashoffset = reduced ? "0" : `${total}`;
-
     let raf = 0;
     const update = () => {
       raf = 0;
@@ -159,15 +170,10 @@ export default function PocTrail() {
       setZone(p < 1 / 3 ? 0 : p < 2 / 3 ? 1 : 2);
       document.documentElement.style.setProperty("--p", `${p}`);
     };
-    const onScroll = () => {
-      if (!raf) raf = requestAnimationFrame(update);
-    };
+    const onScroll = () => { if (!raf) raf = requestAnimationFrame(update); };
     update();
     window.addEventListener("scroll", onScroll, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      if (raf) cancelAnimationFrame(raf);
-    };
+    return () => { window.removeEventListener("scroll", onScroll); if (raf) cancelAnimationFrame(raf); };
   }, [d, reduced]);
 
   const z = ZONES[zone];
@@ -176,49 +182,33 @@ export default function PocTrail() {
     <div className="poc-root">
       <style>{css}</style>
 
-      {/* Sticky translucent nav — where real nav lives */}
       <nav className="poc-nav" aria-label="Primary">
-        <a className="poc-mono" href="#">
-          A<span>|</span>B
-        </a>
+        <a className="poc-mono" href="#">A<span>|</span>B</a>
         <div className="poc-links">
-          <a href="#">About</a>
-          <a href="#">Work</a>
-          <a href="#">Coding</a>
-          <a href="#">Blog</a>
-          <a href="#">Contact</a>
+          <a href="#">About</a><a href="#">Work</a><a href="#">Coding</a>
+          <a href="#">Blog</a><a href="#">Contact</a>
           <span className="poc-kbd">⌘K</span>
         </div>
       </nav>
 
-      <div
-        className="poc-bg"
-        style={{ background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)` }}
-        aria-hidden
-      />
+      {/* sky/color wash */}
+      <div className="poc-bg" style={{ background: `linear-gradient(180deg, ${z.sky} 0%, ${z.bg} 45%, #05060a 100%)` }} aria-hidden />
 
-      <svg
-        className="poc-trail"
-        width={dims.w}
-        height={dims.h}
-        viewBox={`0 0 ${dims.w} ${dims.h}`}
-        fill="none"
-        aria-hidden
-      >
+      {/* biome scenery — color + scenery together */}
+      <div className="poc-scenery" aria-hidden>
+        <Horizon d={SCENERY.far} fill="#ffffff" opacity={0.035} z={1} />
+        <Horizon d={SCENERY.approach} fill="#0e1f16" opacity={zone === 0 ? 1 : 0} z={2} />
+        <Horizon d={SCENERY.crux} fill="#1a1330" opacity={zone === 1 ? 1 : 0} z={2} />
+        <Horizon d={SCENERY.descent} fill="#152233" opacity={zone === 2 ? 1 : 0} z={2} />
+      </div>
+
+      <svg className="poc-trail" width={dims.w} height={dims.h} viewBox={`0 0 ${dims.w} ${dims.h}`} fill="none" aria-hidden>
         <path d={d} stroke="#ffffff" strokeOpacity={0.06} strokeWidth={2.5} />
-        <path
-          ref={pathRef}
-          d={d}
-          stroke={z.accent}
-          strokeWidth={3}
-          strokeLinecap="round"
-          style={{ transition: "stroke 600ms ease" }}
-        />
-        {/* figure rides the path; outer g positioned by JS, inner g idle-bobs */}
+        <path ref={pathRef} d={d} stroke={z.accent} strokeWidth={3} strokeLinecap="round" style={{ transition: "stroke 600ms ease" }} />
         <g ref={markerRef} style={{ opacity: 0 }}>
-          <circle r={14} fill={z.accent} fillOpacity={0.12} />
+          <circle r={15} fill={z.accent} fillOpacity={0.12} />
           <g className={reduced ? "" : "poc-fig"}>
-            <Figure zone={zone} color={z.accent} />
+            <g transform="scale(1.3)"><Figure zone={zone} color={z.accent} /></g>
           </g>
         </g>
       </svg>
@@ -226,11 +216,7 @@ export default function PocTrail() {
       <div className="poc-content">
         <section className="poc-hero">
           <p className="poc-eyebrow">Trailhead</p>
-          <h1>
-            I build the platforms
-            <br />
-            engineers ship on.
-          </h1>
+          <h1>I build the platforms<br />engineers ship on.</h1>
           <p className="poc-lede">Walk the approach. Climb the crux. Ride it out.</p>
           <p className="poc-scrollcue">↓ scroll</p>
         </section>
@@ -238,9 +224,7 @@ export default function PocTrail() {
         {ZONES.map((zn, i) => (
           <section key={zn.key} className="poc-zone">
             <div className="poc-card" style={{ borderColor: zn.accent }}>
-              <p className="poc-eyebrow" style={{ color: zn.accent }}>
-                {String(i + 1).padStart(2, "0")} · {zn.sport} — {zn.label}
-              </p>
+              <p className="poc-eyebrow" style={{ color: zn.accent }}>{String(i + 1).padStart(2, "0")} · {zn.sport} — {zn.label}</p>
               <h2>{zn.heading}</h2>
               <p>{zn.body}</p>
             </div>
@@ -248,9 +232,7 @@ export default function PocTrail() {
         ))}
 
         <section className="poc-summit">
-          <p className="poc-eyebrow" style={{ color: ZONES[1].accent }}>
-            The ride out
-          </p>
+          <p className="poc-eyebrow" style={{ color: ZONES[1].accent }}>The ride out</p>
           <h2>Let&apos;s build something.</h2>
           <p className="poc-lede">Every summit is just the next trailhead.</p>
         </section>
@@ -260,16 +242,15 @@ export default function PocTrail() {
 }
 
 const css = `
-/* hide the site's real header/footer on this POC page only */
 header, footer { display: none !important; }
-
 .poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
 .poc-bg { position: fixed; inset: 0; z-index: 0; transition: background 700ms ease; }
-.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
+.poc-scenery { position: fixed; left: 0; right: 0; bottom: 0; height: 46vh; z-index: 1; pointer-events: none; }
+.poc-horizon { position: absolute; left: 0; bottom: 0; width: 100%; height: 100%; }
 .poc-fig { animation: bob 2.4s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
 @keyframes bob { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(-3px);} }
 
-.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.55); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
+.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.5); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
 .poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
 .poc-mono span { opacity: .5; margin: 0 1px; }
 .poc-links { display: flex; align-items: center; gap: 22px; }
@@ -277,7 +258,8 @@ header, footer { display: none !important; }
 .poc-links a:hover { color: #fff; }
 .poc-kbd { font-size: 11px; color: #9a9aa6; border: 1px solid rgba(255,255,255,.15); border-radius: 6px; padding: 3px 7px; }
 
-.poc-content { position: relative; z-index: 2; max-width: 720px; margin: 0 auto; padding: 0 24px; }
+.poc-content { position: relative; z-index: 3; max-width: 720px; margin: 0 auto; padding: 0 24px; }
+.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 2; pointer-events: none; }
 .poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
 .poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .85; margin: 0 0 16px; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
@@ -286,7 +268,7 @@ header, footer { display: none !important; }
 @keyframes cue { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
 .poc-zone { min-height: 100vh; display: flex; align-items: center; }
 .poc-zone:nth-child(odd) .poc-card { margin-left: auto; }
-.poc-card { background: rgba(12,14,20,.55); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+.poc-card { background: rgba(12,14,20,.62); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
 .poc-card h2 { font-size: clamp(26px, 4vw, 38px); margin: 0 0 12px; font-weight: 600; letter-spacing: -.01em; }
 .poc-card p { margin: 0; color: #c2c2cc; line-height: 1.5; }
 .poc-summit { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,37 +1,37 @@
 "use client";
 
 /**
- * THROWAWAY POC v5 — signature scroll experience over REAL content.
- * Decoupled from the mountain theme (user: "too themed").
- *  - YOUR actual homepage sections & copy (from lib/constants.ts), unrestructured
- *  - signature = abstract trail thread that draws on scroll (no zone labels/theme)
- *    + scroll-reveal choreography + hero metric count-up + sticky nav + ⌘K
- *  - trail line evolves through a cohesive cool palette (aesthetic only, not "zones")
- *  - reduced-motion -> everything visible, trail fully drawn, no count-up
+ * THROWAWAY POC v6 — signature scroll over REAL content.
+ *  - accent aligned to site violet (#a78bfa trail / #7c3aed fill)
+ *  - "Resume" (no accent) per prior decision
+ *  - smart header: transparent+immersive at top, hides on scroll-down,
+ *    reveals as a solid bar on scroll-up (best of sticky + immersive)
+ *  - staggered hero headline reveal (the "memorable" first impression)
+ *  - abstract trail thread + scroll reveals + metric count-up + ⌘K
+ *  - reduced-motion safe
  */
 
 import { useEffect, useRef, useState } from "react";
+
+const TRAIL = "#a78bfa"; // violet-400 — matches site --primary-color (dark)
+const VIOLET = "#7c3aed"; // violet-600 — button fill
 
 const METRICS = [
   { value: "8,000+", label: "enterprise developers" },
   { value: "1,000+", label: "active in 90 days" },
   { value: "10,000+", label: "repos migrated" },
 ];
-
 const ACHIEVEMENTS = [
   { outcome: "A unified developer platform for 8,000+ engineers", skills: ["GitHub Enterprise", "Custom CLI", "IDE Extensions"] },
   { outcome: "1,000+ engineers active in the first 90 days", skills: ["Desktop App", "CLI", "Self-service onboarding"] },
   { outcome: "One build command, any stack — local, CI, or fully remote", skills: ["CI/CD", "Base-image registry", "Containers"] },
   { outcome: "Real-time DevOps intelligence for engineers and AI agents", skills: ["MCP", "AWS", "DynamoDB", "Snowflake"] },
 ];
-
 const NOW = [
   { label: "Homelab", detail: "Proxmox · Docker · Tailscale" },
   { label: "Local-LLM routing", detail: "Ollama · Open WebUI" },
   { label: "AI-native tooling", detail: "Claude Code" },
 ];
-
-const ACCENT = ["#6d8cff", "#9b7cff", "#56b6c2"]; // cohesive cool palette, aesthetic only
 
 function buildSwitchbackPath(h: number, w: number) {
   const cx = w / 2, amp = w / 2 - 18, seg = 300;
@@ -49,8 +49,7 @@ function Metric({ value, label }: { value: string; label: string }) {
   const ref = useRef<HTMLSpanElement>(null);
   const [disp, setDisp] = useState(value);
   useEffect(() => {
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-    if (reduced) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
     const num = parseInt(value.replace(/[^0-9]/g, ""), 10);
     const suffix = value.replace(/[0-9,]/g, "");
     setDisp("0" + suffix);
@@ -63,8 +62,7 @@ function Metric({ value, label }: { value: string; label: string }) {
       const start = performance.now(), dur = 1200;
       const tick = (t: number) => {
         const p = Math.min((t - start) / dur, 1);
-        const eased = 1 - Math.pow(1 - p, 3);
-        setDisp(Math.round(num * eased).toLocaleString() + suffix);
+        setDisp(Math.round(num * (1 - Math.pow(1 - p, 3))).toLocaleString() + suffix);
         if (p < 1) requestAnimationFrame(tick);
       };
       requestAnimationFrame(tick);
@@ -84,9 +82,10 @@ export default function PocTrail() {
   const pathRef = useRef<SVGPathElement>(null);
   const markerRef = useRef<SVGGElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const lastY = useRef(0);
   const [dims, setDims] = useState({ h: 0, w: 300 });
   const [d, setD] = useState("");
-  const [accent, setAccent] = useState(ACCENT[0]);
+  const [nav, setNav] = useState({ hidden: false, atTop: true });
   const [reduced, setReduced] = useState(false);
 
   useEffect(() => {
@@ -102,7 +101,6 @@ export default function PocTrail() {
     return () => window.removeEventListener("resize", measure);
   }, []);
 
-  // scroll-reveal choreography
   useEffect(() => {
     if (reduced) {
       rootRef.current?.querySelectorAll(".reveal").forEach((e) => e.classList.add("in"));
@@ -115,7 +113,6 @@ export default function PocTrail() {
     return () => io.disconnect();
   }, [reduced, d]);
 
-  // trail draw + marker + accent evolution
   useEffect(() => {
     const path = pathRef.current;
     if (!path || !d) return;
@@ -126,15 +123,20 @@ export default function PocTrail() {
     const update = () => {
       raf = 0;
       const el = document.scrollingElement || document.documentElement;
+      const y = el.scrollTop;
       const max = el.scrollHeight - el.clientHeight;
-      const p = max > 0 ? Math.min(Math.max(el.scrollTop / max, 0), 1) : 0;
+      const p = max > 0 ? Math.min(Math.max(y / max, 0), 1) : 0;
       if (!reduced) path.style.strokeDashoffset = `${total * (1 - p)}`;
       const pt = path.getPointAtLength((reduced ? 1 : p) * total);
       if (markerRef.current) {
         markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
         markerRef.current.style.opacity = reduced ? "0" : "1";
       }
-      setAccent(ACCENT[p < 0.4 ? 0 : p < 0.72 ? 1 : 2]);
+      // smart header
+      const atTop = y < 40;
+      const hidden = !atTop && y > lastY.current && y > 90;
+      setNav((s) => (s.hidden === hidden && s.atTop === atTop ? s : { hidden, atTop }));
+      lastY.current = y;
     };
     const onScroll = () => { if (!raf) raf = requestAnimationFrame(update); };
     update();
@@ -146,7 +148,7 @@ export default function PocTrail() {
     <div className="poc-root" ref={rootRef}>
       <style>{css}</style>
 
-      <nav className="poc-nav" aria-label="Primary">
+      <nav className={`poc-nav${nav.atTop ? " attop" : ""}${nav.hidden ? " hidden" : ""}`} aria-label="Primary">
         <a className="poc-mono" href="#">A<span>|</span>B</a>
         <div className="poc-links">
           <a href="#about">About</a><a href="#work">Work</a><a href="#">Coding</a>
@@ -159,35 +161,35 @@ export default function PocTrail() {
 
       <svg className="poc-trail" width={dims.w} height={dims.h} viewBox={`0 0 ${dims.w} ${dims.h}`} fill="none" aria-hidden>
         <path d={d} stroke="#ffffff" strokeOpacity={0.055} strokeWidth={2.5} />
-        <path ref={pathRef} d={d} stroke={accent} strokeWidth={2.5} strokeLinecap="round" style={{ transition: "stroke 800ms ease" }} />
+        <path ref={pathRef} d={d} stroke={TRAIL} strokeWidth={2.5} strokeLinecap="round" />
         <g ref={markerRef} style={{ opacity: 0 }}>
-          <circle r={10} fill={accent} fillOpacity={0.18} />
-          <circle r={4.5} fill={accent} />
+          <circle r={10} fill={TRAIL} fillOpacity={0.18} />
+          <circle r={4.5} fill={TRAIL} />
         </g>
       </svg>
 
       <div className="poc-content">
-        {/* HERO */}
         <section className="poc-hero">
           <p className="poc-eyebrow reveal">Anthony Brignano</p>
-          <h1 className="reveal">I build the platforms<br />engineers ship on.</h1>
-          <p className="poc-lede reveal">Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes onboarding self-service and delivery faster and safer.</p>
-          <div className="poc-metrics reveal">
+          <h1>
+            <span className="reveal" style={{ transitionDelay: "60ms" }}>I build the platforms</span>
+            <span className="reveal" style={{ transitionDelay: "160ms" }}>engineers ship on.</span>
+          </h1>
+          <p className="poc-lede reveal" style={{ transitionDelay: "240ms" }}>Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes onboarding self-service and delivery faster and safer.</p>
+          <div className="poc-metrics reveal" style={{ transitionDelay: "320ms" }}>
             {METRICS.map((m) => <Metric key={m.label} value={m.value} label={m.label} />)}
           </div>
-          <div className="poc-cta reveal">
-            <a className="btn primary" style={{ background: accent }} href="#">Résumé</a>
+          <div className="poc-cta reveal" style={{ transitionDelay: "400ms" }}>
+            <a className="btn primary" href="#">Resume</a>
             <a className="btn ghost" href="#">Coding activity</a>
           </div>
         </section>
 
-        {/* ABOUT */}
         <section id="about" className="poc-sec">
           <h2 className="reveal">About</h2>
           <p className="poc-prose reveal">I lead the internal developer platform thousands of engineers build on — chasing clean abstractions, fast feedback loops, and making the right thing the easy thing. Off the clock: homelab tinkering, local-LLM experiments, and time on rock, snow, and trail.</p>
         </section>
 
-        {/* WORK / HIGHLIGHTS */}
         <section id="work" className="poc-sec">
           <h2 className="reveal">Highlights</h2>
           <div className="poc-grid">
@@ -200,13 +202,10 @@ export default function PocTrail() {
           </div>
           <div className="poc-now reveal">
             <span className="now-eyebrow">Now building</span>
-            {NOW.map((n) => (
-              <span key={n.label} className="now-item"><strong>{n.label}</strong> {n.detail}</span>
-            ))}
+            {NOW.map((n) => <span key={n.label} className="now-item"><strong>{n.label}</strong> {n.detail}</span>)}
           </div>
         </section>
 
-        {/* CURRENT ROLE */}
         <section className="poc-sec">
           <h2 className="reveal">Current role</h2>
           <ul className="poc-bullets">
@@ -215,23 +214,21 @@ export default function PocTrail() {
             <li className="reveal">Real-time DevOps intelligence streaming telemetry into AWS, DynamoDB, and Snowflake; native AI tooling via MCP.</li>
             <li className="reveal">Operating the enterprise CI/CD + DevSecOps toolchain end to end across thousands of pipelines.</li>
           </ul>
+          <p className="poc-inline reveal">For my full career history, see <a href="#">my resume</a>.</p>
         </section>
 
-        {/* OPEN SOURCE */}
         <section className="poc-sec">
           <h2 className="reveal">Open-source activity</h2>
           <div className="poc-cal reveal" aria-hidden>
-            {Array.from({ length: 120 }).map((_, i) => (
-              <span key={i} className="cell" style={{ opacity: 0.12 + ((i * 37) % 7) / 9 }} />
-            ))}
+            {Array.from({ length: 120 }).map((_, i) => <span key={i} className="cell" style={{ opacity: 0.12 + ((i * 37) % 7) / 9 }} />)}
           </div>
+          <p className="poc-inline reveal">For more detailed information, see <a href="#">my coding activity</a>.</p>
         </section>
 
-        {/* CONTACT */}
         <section id="contact" className="poc-contact">
           <h2 className="reveal">Let&apos;s build something.</h2>
           <p className="poc-lede reveal">Always up for a good problem.</p>
-          <a className="btn primary reveal" style={{ background: accent }} href="#">hi@brignano.io</a>
+          <a className="btn primary reveal" href="#">hi@brignano.io</a>
         </section>
       </div>
     </div>
@@ -243,7 +240,9 @@ header, footer { display: none !important; }
 .poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
 .poc-bg { position: fixed; inset: 0; z-index: 0; background: radial-gradient(120% 80% at 50% -10%, #0c0d13 0%, #050609 70%); }
 
-.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.5); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
+.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.6); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.07); transition: transform .35s ease, background .35s ease, border-color .35s ease, backdrop-filter .35s ease; }
+.poc-nav.attop { background: transparent; border-color: transparent; backdrop-filter: none; }
+.poc-nav.hidden { transform: translateY(-100%); }
 .poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
 .poc-mono span { opacity: .5; margin: 0 1px; }
 .poc-links { display: flex; align-items: center; gap: 22px; }
@@ -260,6 +259,7 @@ header, footer { display: none !important; }
 .poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .85; margin: 0 0 16px; }
 .poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
+.poc-hero h1 span { display: block; }
 .poc-lede { font-size: clamp(16px, 2.1vw, 20px); color: #c8c8d0; max-width: 54ch; line-height: 1.5; }
 .poc-metrics { display: flex; gap: 40px; margin: 36px 0 32px; flex-wrap: wrap; }
 .m-metric { display: flex; flex-direction: column; }
@@ -268,8 +268,8 @@ header, footer { display: none !important; }
 .poc-cta { display: flex; gap: 14px; flex-wrap: wrap; }
 .btn { display: inline-block; padding: 11px 20px; border-radius: 10px; font-size: 14px; font-weight: 500; text-decoration: none; transition: transform .15s ease, filter .15s ease; }
 .btn:hover { transform: translateY(-2px); }
-.btn.primary { color: #0a0a0f; }
-.btn.primary:hover { filter: brightness(1.08); }
+.btn.primary { background: ${VIOLET}; color: #fff; }
+.btn.primary:hover { filter: brightness(1.1); }
 .btn.ghost { color: #e6e6ea; border: 1px solid rgba(255,255,255,.2); }
 
 .poc-sec { padding: 12vh 0; }
@@ -287,8 +287,10 @@ header, footer { display: none !important; }
 .poc-bullets { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 16px; max-width: 64ch; }
 .poc-bullets li { position: relative; padding-left: 20px; color: #c8c8d0; line-height: 1.5; }
 .poc-bullets li::before { content: "—"; position: absolute; left: 0; color: #7b7b88; }
+.poc-inline { margin-top: 22px; font-size: 14px; color: #9a9aa6; }
+.poc-inline a { color: ${TRAIL}; text-decoration: underline; text-underline-offset: 3px; }
 .poc-cal { display: grid; grid-template-columns: repeat(20, 1fr); gap: 5px; max-width: 540px; }
-.cell { aspect-ratio: 1; border-radius: 3px; background: #8b9bff; }
+.cell { aspect-ratio: 1; border-radius: 3px; background: ${TRAIL}; }
 .poc-contact { min-height: 80vh; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; }
 .poc-contact h2 { font-size: clamp(34px, 6vw, 58px); font-weight: 600; letter-spacing: -.02em; margin: 0 0 14px; }
 .poc-contact .btn { margin-top: 22px; }

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,40 +1,48 @@
 "use client";
 
 /**
- * THROWAWAY POC — signature "Trail" experience (TSD P0 taste gate).
- * Not production code. Self-contained on purpose so it's easy to delete.
- * Demonstrates: scroll-drawn switchback trail (SVG stroke-dashoffset),
- * a marker that rides the path, three altitude zones with ambient hue
- * shifts, waypoints, and reduced-motion -> static complete trail.
+ * THROWAWAY POC v2 — signature "Trail" experience (TSD P0 taste gate).
+ * Not production code. Demonstrates the FULL layout:
+ *  - sticky translucent nav (where real nav lives)
+ *  - real-content scaffolding sitting in cards along the trail
+ *  - a pose-swap FIGURE that rides the path: hike -> climb -> snowboard
+ *  - Option 2 ordering (walk the approach, climb the crux, ride the descent)
+ *  - reduced-motion -> static complete trail, no idle bob
  */
 
 import { useEffect, useRef, useState } from "react";
 
-// Option 1 (Ascent): approach -> slopes -> summit. Climb = apex.
+// Option 2 (expedition day): approach -> crux -> descent.
 const ZONES = [
   {
     key: "approach",
     sport: "Hike",
     label: "The approach",
-    sub: "Foundations — showing up, the grind before the reward.",
-    accent: "#6f9e6f", // moss
+    sub: "Foundations — showing up, the long walk in before anything happens.",
+    heading: "About",
+    body: "Platform engineer who likes hard problems and clean abstractions. The work — and the mountains — both start with the approach.",
+    accent: "#6f9e6f",
     bg: "#0a120d",
   },
   {
-    key: "slopes",
-    sport: "Snowboard",
-    label: "The slopes",
-    sub: "Momentum — flow, speed, reading the terrain.",
-    accent: "#6fa8d6", // ice
-    bg: "#0a1019",
+    key: "crux",
+    sport: "Climb",
+    label: "The crux",
+    sub: "The hardest move — focus, commitment, the part that matters.",
+    heading: "The work",
+    body: "Internal developer platforms for thousands of engineers — CI/CD, DevOps intelligence, and AI-native tooling. The crux: make shipping safe and fast.",
+    accent: "#9b7cff", // violet — the summit/crux color
+    bg: "#120e1c",
   },
   {
-    key: "summit",
-    sport: "Climb",
-    label: "The summit",
-    sub: "The crux — focus, commitment, the move that matters.",
-    accent: "#9b7cff", // violet (summit accent)
-    bg: "#120e1c",
+    key: "descent",
+    sport: "Snowboard",
+    label: "The descent",
+    sub: "Flow — the reward, reading the terrain, the ride out.",
+    heading: "Off the clock",
+    body: "Homelab, local-LLM routing, AI-native tooling with Claude Code — and when the screens are off, snowboarding through the woods.",
+    accent: "#6fa8d6",
+    bg: "#0a1019",
   },
 ] as const;
 
@@ -57,6 +65,56 @@ function buildSwitchbackPath(h: number, w: number) {
   return d;
 }
 
+// --- pose-swap line-art figures (rough POC art; refine later) ---
+function Figure({ zone, color }: { zone: number; color: string }) {
+  const s = {
+    stroke: color,
+    strokeWidth: 1.6,
+    strokeLinecap: "round" as const,
+    strokeLinejoin: "round" as const,
+    fill: "none",
+  };
+  if (zone === 0) {
+    // hiker: walking with a trekking pole
+    return (
+      <g {...s}>
+        <circle cx={0} cy={-12} r={2.6} fill={color} stroke="none" />
+        <path d="M0 -9 L0 0" />
+        <path d="M0 0 L-4 7" />
+        <path d="M0 0 L4 6" />
+        <path d="M0 -6 L5 -3" />
+        <path d="M5 -3 L6 8" />
+      </g>
+    );
+  }
+  if (zone === 1) {
+    // climber: reaching up on a wall
+    return (
+      <g {...s}>
+        <path d="M9 -16 L9 9" strokeOpacity={0.35} />
+        <circle cx={2} cy={-12} r={2.6} fill={color} stroke="none" />
+        <path d="M2 -9 L0 0" />
+        <path d="M2 -8 L7 -15" />
+        <path d="M0 -6 L-4 -3" />
+        <path d="M0 0 L-3 8" />
+        <path d="M0 0 L4 6" />
+      </g>
+    );
+  }
+  // snowboarder: crouched on a board
+  return (
+    <g {...s}>
+      <path d="M-9 8 L9 6" strokeWidth={2.2} />
+      <path d="M-3 7 L-1 0" />
+      <path d="M4 6 L1 0" />
+      <path d="M0 0 L1 -7" />
+      <circle cx={1} cy={-10} r={2.6} fill={color} stroke="none" />
+      <path d="M0 -4 L-7 -6" />
+      <path d="M0 -4 L8 -3" />
+    </g>
+  );
+}
+
 export default function PocTrail() {
   const pathRef = useRef<SVGPathElement>(null);
   const markerRef = useRef<SVGGElement>(null);
@@ -65,7 +123,6 @@ export default function PocTrail() {
   const [zone, setZone] = useState(0);
   const [reduced, setReduced] = useState(false);
 
-  // Measure + build path
   useEffect(() => {
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     setReduced(mq.matches);
@@ -80,7 +137,6 @@ export default function PocTrail() {
     return () => window.removeEventListener("resize", measure);
   }, []);
 
-  // Drive draw + marker + zone on scroll
   useEffect(() => {
     const path = pathRef.current;
     if (!path || !d) return;
@@ -95,13 +151,12 @@ export default function PocTrail() {
       const max = el.scrollHeight - el.clientHeight;
       const p = max > 0 ? Math.min(Math.max(el.scrollTop / max, 0), 1) : 0;
       if (!reduced) path.style.strokeDashoffset = `${total * (1 - p)}`;
-      const pt = path.getPointAtLength(p * total);
+      const pt = path.getPointAtLength((reduced ? 1 : p) * total);
       if (markerRef.current) {
         markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
-        markerRef.current.style.opacity = reduced ? "0" : "1";
+        markerRef.current.style.opacity = "1";
       }
-      const z = p < 1 / 3 ? 0 : p < 2 / 3 ? 1 : 2;
-      setZone(z);
+      setZone(p < 1 / 3 ? 0 : p < 2 / 3 ? 1 : 2);
       document.documentElement.style.setProperty("--p", `${p}`);
     };
     const onScroll = () => {
@@ -121,16 +176,27 @@ export default function PocTrail() {
     <div className="poc-root">
       <style>{css}</style>
 
-      {/* Ambient background that shifts per zone */}
+      {/* Sticky translucent nav — where real nav lives */}
+      <nav className="poc-nav" aria-label="Primary">
+        <a className="poc-mono" href="#">
+          A<span>|</span>B
+        </a>
+        <div className="poc-links">
+          <a href="#">About</a>
+          <a href="#">Work</a>
+          <a href="#">Coding</a>
+          <a href="#">Blog</a>
+          <a href="#">Contact</a>
+          <span className="poc-kbd">⌘K</span>
+        </div>
+      </nav>
+
       <div
         className="poc-bg"
-        style={{
-          background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)`,
-        }}
+        style={{ background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)` }}
         aria-hidden
       />
 
-      {/* The trail */}
       <svg
         className="poc-trail"
         width={dims.w}
@@ -139,9 +205,7 @@ export default function PocTrail() {
         fill="none"
         aria-hidden
       >
-        {/* faint full path (the trail ahead) */}
         <path d={d} stroke="#ffffff" strokeOpacity={0.06} strokeWidth={2.5} />
-        {/* drawn path (where you've been) */}
         <path
           ref={pathRef}
           d={d}
@@ -150,14 +214,15 @@ export default function PocTrail() {
           strokeLinecap="round"
           style={{ transition: "stroke 600ms ease" }}
         />
-        {/* moving marker */}
-        <g ref={markerRef} style={{ transition: "opacity 300ms" }}>
-          <circle r={11} fill={z.accent} fillOpacity={0.2} />
-          <circle r={5} fill={z.accent} />
+        {/* figure rides the path; outer g positioned by JS, inner g idle-bobs */}
+        <g ref={markerRef} style={{ opacity: 0 }}>
+          <circle r={14} fill={z.accent} fillOpacity={0.12} />
+          <g className={reduced ? "" : "poc-fig"}>
+            <Figure zone={zone} color={z.accent} />
+          </g>
         </g>
       </svg>
 
-      {/* Content */}
       <div className="poc-content">
         <section className="poc-hero">
           <p className="poc-eyebrow">Trailhead</p>
@@ -166,30 +231,28 @@ export default function PocTrail() {
             <br />
             engineers ship on.
           </h1>
-          <p className="poc-lede">
-            Every route starts at the trailhead. Scroll to follow the climb.
-          </p>
+          <p className="poc-lede">Walk the approach. Climb the crux. Ride it out.</p>
           <p className="poc-scrollcue">↓ scroll</p>
         </section>
 
-        {ZONES.map((zone, i) => (
-          <section key={zone.key} className="poc-zone">
-            <div className="poc-card" style={{ borderColor: zone.accent }}>
-              <p className="poc-eyebrow" style={{ color: zone.accent }}>
-                {String(i + 1).padStart(2, "0")} · {zone.sport}
+        {ZONES.map((zn, i) => (
+          <section key={zn.key} className="poc-zone">
+            <div className="poc-card" style={{ borderColor: zn.accent }}>
+              <p className="poc-eyebrow" style={{ color: zn.accent }}>
+                {String(i + 1).padStart(2, "0")} · {zn.sport} — {zn.label}
               </p>
-              <h2>{zone.label}</h2>
-              <p>{zone.sub}</p>
+              <h2>{zn.heading}</h2>
+              <p>{zn.body}</p>
             </div>
           </section>
         ))}
 
         <section className="poc-summit">
-          <p className="poc-eyebrow" style={{ color: ZONES[2].accent }}>
-            The peak
+          <p className="poc-eyebrow" style={{ color: ZONES[1].accent }}>
+            The ride out
           </p>
           <h2>Let&apos;s build something.</h2>
-          <p className="poc-lede">The summit is just the next trailhead.</p>
+          <p className="poc-lede">Every summit is just the next trailhead.</p>
         </section>
       </div>
     </div>
@@ -197,16 +260,30 @@ export default function PocTrail() {
 }
 
 const css = `
+/* hide the site's real header/footer on this POC page only */
+header, footer { display: none !important; }
+
 .poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
 .poc-bg { position: fixed; inset: 0; z-index: 0; transition: background 700ms ease; }
 .poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
+.poc-fig { animation: bob 2.4s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+@keyframes bob { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(-3px);} }
+
+.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.55); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
+.poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
+.poc-mono span { opacity: .5; margin: 0 1px; }
+.poc-links { display: flex; align-items: center; gap: 22px; }
+.poc-links a { color: #c8c8d0; text-decoration: none; font-size: 14px; transition: color .2s; }
+.poc-links a:hover { color: #fff; }
+.poc-kbd { font-size: 11px; color: #9a9aa6; border: 1px solid rgba(255,255,255,.15); border-radius: 6px; padding: 3px 7px; }
+
 .poc-content { position: relative; z-index: 2; max-width: 720px; margin: 0 auto; padding: 0 24px; }
 .poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
-.poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .8; margin: 0 0 16px; }
+.poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .85; margin: 0 0 16px; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
-.poc-lede { font-size: clamp(16px, 2.2vw, 20px); color: #c8c8d0; max-width: 38ch; }
-.poc-scrollcue { margin-top: 48px; font-size: 13px; letter-spacing: .3em; text-transform: uppercase; opacity: .5; animation: bob 1.8s ease-in-out infinite; }
-@keyframes bob { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
+.poc-lede { font-size: clamp(16px, 2.2vw, 20px); color: #c8c8d0; max-width: 40ch; }
+.poc-scrollcue { margin-top: 48px; font-size: 13px; letter-spacing: .3em; text-transform: uppercase; opacity: .5; animation: cue 1.8s ease-in-out infinite; }
+@keyframes cue { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
 .poc-zone { min-height: 100vh; display: flex; align-items: center; }
 .poc-zone:nth-child(odd) .poc-card { margin-left: auto; }
 .poc-card { background: rgba(12,14,20,.55); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
@@ -214,5 +291,5 @@ const css = `
 .poc-card p { margin: 0; color: #c2c2cc; line-height: 1.5; }
 .poc-summit { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
 .poc-summit h2 { font-size: clamp(34px, 6vw, 60px); margin: 0 0 16px; font-weight: 600; letter-spacing: -.02em; }
-@media (prefers-reduced-motion: reduce) { .poc-scrollcue { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .poc-scrollcue, .poc-fig { animation: none; } }
 `;

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -31,16 +31,18 @@ const NOW = [
   { label: "AI-native tooling", detail: "Claude Code" },
 ];
 
-// Trail anchored to the monogram (top-left), sweeping to center then switchbacks.
+// Trail lives in the LEFT GUTTER (never behind text), a gentle serpentine
+// that starts below the header (no overlap with the fixed nav).
 function buildPath(h: number, vw: number) {
-  const cx = vw / 2;
-  const amp = Math.min(Math.max(vw * 0.13, 90), 165);
-  const sx = 60, sy = 52, introEnd = 540;
-  let d = `M ${sx} ${sy} C ${sx} ${sy + 180}, ${cx - amp} ${introEnd - 160}, ${cx} ${introEnd}`;
-  const rest = h - introEnd, n = Math.max(5, Math.round(rest / 300)), step = rest / n;
-  let xprev = cx, y = introEnd;
+  const contentLeft = Math.max(24, (vw - 880) / 2);
+  const wide = contentLeft > 150;
+  const ax = wide ? Math.round(contentLeft * 0.5) : 20; // spine x within the gutter
+  const amp = wide ? Math.min(Math.round(contentLeft * 0.22), 44) : 7;
+  const top = 88; // start below the header
+  const rest = h - top, n = Math.max(4, Math.round(rest / 360)), step = rest / n;
+  let xprev = ax, y = top, d = `M ${ax} ${top}`;
   for (let i = 1; i <= n; i++) {
-    const ny = introEnd + i * step, x = i % 2 ? cx + amp : cx - amp;
+    const ny = top + i * step, x = i % 2 ? ax + amp : ax - amp;
     d += ` C ${xprev} ${y + step * 0.5}, ${x} ${ny - step * 0.5}, ${x} ${ny}`;
     xprev = x; y = ny;
   }

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,20 +1,18 @@
 "use client";
 
 /**
- * THROWAWAY POC v6 — signature scroll over REAL content.
- *  - accent aligned to site violet (#a78bfa trail / #7c3aed fill)
- *  - "Resume" (no accent) per prior decision
- *  - smart header: transparent+immersive at top, hides on scroll-down,
- *    reveals as a solid bar on scroll-up (best of sticky + immersive)
- *  - staggered hero headline reveal (the "memorable" first impression)
- *  - abstract trail thread + scroll reveals + metric count-up + ⌘K
- *  - reduced-motion safe
+ * THROWAWAY POC v7 — signature scroll over REAL content.
+ *  - trail now ANCHORED to the A|B monogram (origin = brand)
+ *  - working ⌘K command palette (open via ⌘K / Ctrl+K or the chip)
+ *  - working light/dark theme toggle (CSS variables)
+ *  - smart header, staggered hero, metric count-up, scroll reveals
+ *  - violet accent (#a78bfa / #7c3aed), reduced-motion safe
+ *  (Page-to-page View Transitions are a multi-route feature -> TSD, not POC.)
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 
-const TRAIL = "#a78bfa"; // violet-400 — matches site --primary-color (dark)
-const VIOLET = "#7c3aed"; // violet-600 — button fill
+const VIOLET = "#7c3aed";
 
 const METRICS = [
   { value: "8,000+", label: "enterprise developers" },
@@ -33,14 +31,18 @@ const NOW = [
   { label: "AI-native tooling", detail: "Claude Code" },
 ];
 
-function buildSwitchbackPath(h: number, w: number) {
-  const cx = w / 2, amp = w / 2 - 18, seg = 300;
-  const n = Math.max(6, Math.round(h / seg)), step = h / n;
-  let xprev = cx, d = `M ${cx} 0`;
+// Trail anchored to the monogram (top-left), sweeping to center then switchbacks.
+function buildPath(h: number, vw: number) {
+  const cx = vw / 2;
+  const amp = Math.min(Math.max(vw * 0.13, 90), 165);
+  const sx = 60, sy = 52, introEnd = 540;
+  let d = `M ${sx} ${sy} C ${sx} ${sy + 180}, ${cx - amp} ${introEnd - 160}, ${cx} ${introEnd}`;
+  const rest = h - introEnd, n = Math.max(5, Math.round(rest / 300)), step = rest / n;
+  let xprev = cx, y = introEnd;
   for (let i = 1; i <= n; i++) {
-    const ny = i * step, x = i % 2 ? cx + amp : cx - amp;
-    d += ` C ${xprev} ${(i - 1) * step + step * 0.5}, ${x} ${ny - step * 0.5}, ${x} ${ny}`;
-    xprev = x;
+    const ny = introEnd + i * step, x = i % 2 ? cx + amp : cx - amp;
+    d += ` C ${xprev} ${y + step * 0.5}, ${x} ${ny - step * 0.5}, ${x} ${ny}`;
+    xprev = x; y = ny;
   }
   return d;
 }
@@ -56,12 +58,12 @@ function Metric({ value, label }: { value: string; label: string }) {
     const el = ref.current;
     if (!el || !num) return;
     let done = false;
-    const io = new IntersectionObserver((entries) => {
-      if (!entries[0].isIntersecting || done) return;
+    const io = new IntersectionObserver((es) => {
+      if (!es[0].isIntersecting || done) return;
       done = true;
-      const start = performance.now(), dur = 1200;
+      const start = performance.now();
       const tick = (t: number) => {
-        const p = Math.min((t - start) / dur, 1);
+        const p = Math.min((t - start) / 1200, 1);
         setDisp(Math.round(num * (1 - Math.pow(1 - p, 3))).toLocaleString() + suffix);
         if (p < 1) requestAnimationFrame(tick);
       };
@@ -70,12 +72,7 @@ function Metric({ value, label }: { value: string; label: string }) {
     io.observe(el);
     return () => io.disconnect();
   }, [value]);
-  return (
-    <div className="m-metric">
-      <span ref={ref} className="m-num">{disp}</span>
-      <span className="m-label">{label}</span>
-    </div>
-  );
+  return <div className="m-metric"><span ref={ref} className="m-num">{disp}</span><span className="m-label">{label}</span></div>;
 }
 
 export default function PocTrail() {
@@ -83,32 +80,57 @@ export default function PocTrail() {
   const markerRef = useRef<SVGGElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const lastY = useRef(0);
-  const [dims, setDims] = useState({ h: 0, w: 300 });
+  const [dims, setDims] = useState({ h: 0, w: 1200 });
   const [d, setD] = useState("");
   const [nav, setNav] = useState({ hidden: false, atTop: true });
   const [reduced, setReduced] = useState(false);
+  const [light, setLight] = useState(false);
+  const [palette, setPalette] = useState(false);
+  const [q, setQ] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const go = useCallback((id?: string) => {
+    setPalette(false);
+    if (id) document.getElementById(id)?.scrollIntoView({ behavior: reduced ? "auto" : "smooth" });
+  }, [reduced]);
+
+  const commands = [
+    { label: "About", hint: "section", run: () => go("about") },
+    { label: "Work / Highlights", hint: "section", run: () => go("work") },
+    { label: "Coding activity", hint: "page", run: () => go() },
+    { label: "Blog", hint: "page", run: () => go() },
+    { label: "Contact", hint: "section", run: () => go("contact") },
+    { label: "Resume", hint: "page", run: () => go() },
+    { label: light ? "Switch to dark" : "Switch to light", hint: "theme", run: () => { setLight((v) => !v); setPalette(false); } },
+  ];
+  const filtered = commands.filter((c) => c.label.toLowerCase().includes(q.toLowerCase()));
 
   useEffect(() => {
     setReduced(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
     const measure = () => {
       const h = document.documentElement.scrollHeight;
-      const w = Math.min(Math.max(window.innerWidth * 0.45, 200), 340);
-      setDims({ h, w });
-      setD(buildSwitchbackPath(h, w));
+      setDims({ h, w: window.innerWidth });
+      setD(buildPath(h, window.innerWidth));
     };
     measure();
     window.addEventListener("resize", measure);
     return () => window.removeEventListener("resize", measure);
   }, []);
 
+  // ⌘K / Ctrl+K + Escape
   useEffect(() => {
-    if (reduced) {
-      rootRef.current?.querySelectorAll(".reveal").forEach((e) => e.classList.add("in"));
-      return;
-    }
-    const io = new IntersectionObserver((entries) => {
-      entries.forEach((e) => { if (e.isIntersecting) e.target.classList.add("in"); });
-    }, { threshold: 0.18 });
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") { e.preventDefault(); setPalette((v) => !v); }
+      else if (e.key === "Escape") setPalette(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+  useEffect(() => { if (palette) { setQ(""); setTimeout(() => inputRef.current?.focus(), 30); } }, [palette]);
+
+  useEffect(() => {
+    if (reduced) { rootRef.current?.querySelectorAll(".reveal").forEach((e) => e.classList.add("in")); return; }
+    const io = new IntersectionObserver((es) => es.forEach((e) => { if (e.isIntersecting) e.target.classList.add("in"); }), { threshold: 0.18 });
     rootRef.current?.querySelectorAll(".reveal").forEach((e) => io.observe(e));
     return () => io.disconnect();
   }, [reduced, d]);
@@ -123,8 +145,7 @@ export default function PocTrail() {
     const update = () => {
       raf = 0;
       const el = document.scrollingElement || document.documentElement;
-      const y = el.scrollTop;
-      const max = el.scrollHeight - el.clientHeight;
+      const y = el.scrollTop, max = el.scrollHeight - el.clientHeight;
       const p = max > 0 ? Math.min(Math.max(y / max, 0), 1) : 0;
       if (!reduced) path.style.strokeDashoffset = `${total * (1 - p)}`;
       const pt = path.getPointAtLength((reduced ? 1 : p) * total);
@@ -132,7 +153,6 @@ export default function PocTrail() {
         markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
         markerRef.current.style.opacity = reduced ? "0" : "1";
       }
-      // smart header
       const atTop = y < 40;
       const hidden = !atTop && y > lastY.current && y > 90;
       setNav((s) => (s.hidden === hidden && s.atTop === atTop ? s : { hidden, atTop }));
@@ -145,7 +165,7 @@ export default function PocTrail() {
   }, [d, reduced]);
 
   return (
-    <div className="poc-root" ref={rootRef}>
+    <div className="poc-root" ref={rootRef} data-light={light ? "" : undefined}>
       <style>{css}</style>
 
       <nav className={`poc-nav${nav.atTop ? " attop" : ""}${nav.hidden ? " hidden" : ""}`} aria-label="Primary">
@@ -153,18 +173,19 @@ export default function PocTrail() {
         <div className="poc-links">
           <a href="#about">About</a><a href="#work">Work</a><a href="#">Coding</a>
           <a href="#">Blog</a><a href="#contact">Contact</a>
-          <span className="poc-kbd">⌘K</span>
+          <button className="poc-theme" onClick={() => setLight((v) => !v)} aria-label="Toggle theme">{light ? "☾" : "☀"}</button>
+          <button className="poc-kbd" onClick={() => setPalette(true)} aria-label="Open command palette">⌘K</button>
         </div>
       </nav>
 
       <div className="poc-bg" aria-hidden />
 
       <svg className="poc-trail" width={dims.w} height={dims.h} viewBox={`0 0 ${dims.w} ${dims.h}`} fill="none" aria-hidden>
-        <path d={d} stroke="#ffffff" strokeOpacity={0.055} strokeWidth={2.5} />
-        <path ref={pathRef} d={d} stroke={TRAIL} strokeWidth={2.5} strokeLinecap="round" />
+        <path className="trail-faint" d={d} strokeWidth={2.5} />
+        <path ref={pathRef} d={d} stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" />
         <g ref={markerRef} style={{ opacity: 0 }}>
-          <circle r={10} fill={TRAIL} fillOpacity={0.18} />
-          <circle r={4.5} fill={TRAIL} />
+          <circle r={10} fill="currentColor" fillOpacity={0.18} />
+          <circle r={4.5} fill="currentColor" />
         </g>
       </svg>
 
@@ -176,9 +197,7 @@ export default function PocTrail() {
             <span className="reveal" style={{ transitionDelay: "160ms" }}>engineers ship on.</span>
           </h1>
           <p className="poc-lede reveal" style={{ transitionDelay: "240ms" }}>Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes onboarding self-service and delivery faster and safer.</p>
-          <div className="poc-metrics reveal" style={{ transitionDelay: "320ms" }}>
-            {METRICS.map((m) => <Metric key={m.label} value={m.value} label={m.label} />)}
-          </div>
+          <div className="poc-metrics reveal" style={{ transitionDelay: "320ms" }}>{METRICS.map((m) => <Metric key={m.label} {...m} />)}</div>
           <div className="poc-cta reveal" style={{ transitionDelay: "400ms" }}>
             <a className="btn primary" href="#">Resume</a>
             <a className="btn ghost" href="#">Coding activity</a>
@@ -219,9 +238,7 @@ export default function PocTrail() {
 
         <section className="poc-sec">
           <h2 className="reveal">Open-source activity</h2>
-          <div className="poc-cal reveal" aria-hidden>
-            {Array.from({ length: 120 }).map((_, i) => <span key={i} className="cell" style={{ opacity: 0.12 + ((i * 37) % 7) / 9 }} />)}
-          </div>
+          <div className="poc-cal reveal" aria-hidden>{Array.from({ length: 120 }).map((_, i) => <span key={i} className="cell" style={{ opacity: 0.12 + ((i * 37) % 7) / 9 }} />)}</div>
           <p className="poc-inline reveal">For more detailed information, see <a href="#">my coding activity</a>.</p>
         </section>
 
@@ -231,26 +248,58 @@ export default function PocTrail() {
           <a className="btn primary reveal" href="#">hi@brignano.io</a>
         </section>
       </div>
+
+      {palette && (
+        <div className="cmdk-overlay" onClick={() => setPalette(false)}>
+          <div className="cmdk" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Command palette">
+            <input ref={inputRef} value={q} onChange={(e) => setQ(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter" && filtered[0]) filtered[0].run(); }}
+              placeholder="Type a command or search…" />
+            <ul>
+              {filtered.length === 0 && <li className="cmdk-empty">No results</li>}
+              {filtered.map((c) => (
+                <li key={c.label} onClick={c.run}><span>{c.label}</span><span className="cmdk-hint">{c.hint}</span></li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
 
 const css = `
 header, footer { display: none !important; }
-.poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
-.poc-bg { position: fixed; inset: 0; z-index: 0; background: radial-gradient(120% 80% at 50% -10%, #0c0d13 0%, #050609 70%); }
+.poc-root {
+  --bg1:#0c0d13; --bg2:#050609; --fg:#f2f2f5; --muted:#c8c8d0; --muted2:#9a9aa6;
+  --card:rgba(14,16,22,.55); --card-solid:#14161d; --border:rgba(255,255,255,.08);
+  --nav:rgba(8,9,13,.6); --navborder:rgba(255,255,255,.07); --faint:rgba(255,255,255,.06);
+  --pill:rgba(255,255,255,.14); --hover:rgba(255,255,255,.06); --trail:#a78bfa;
+  position: relative; color: var(--fg); font-family: var(--font-geist, ui-sans-serif, system-ui);
+}
+.poc-root[data-light] {
+  --bg1:#f4f4f7; --bg2:#e9e9ee; --fg:#16161a; --muted:#3c3c44; --muted2:#6a6a74;
+  --card:rgba(255,255,255,.72); --card-solid:#ffffff; --border:rgba(0,0,0,.1);
+  --nav:rgba(255,255,255,.65); --navborder:rgba(0,0,0,.08); --faint:rgba(0,0,0,.07);
+  --pill:rgba(0,0,0,.14); --hover:rgba(0,0,0,.05); --trail:#7c3aed;
+}
+.poc-bg { position: fixed; inset: 0; z-index: 0; background: radial-gradient(120% 80% at 50% -10%, var(--bg1) 0%, var(--bg2) 70%); transition: background .4s ease; }
 
-.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.6); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.07); transition: transform .35s ease, background .35s ease, border-color .35s ease, backdrop-filter .35s ease; }
+.poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: var(--nav); backdrop-filter: blur(10px); border-bottom: 1px solid var(--navborder); transition: transform .35s ease, background .35s ease, border-color .35s ease, backdrop-filter .35s ease; }
 .poc-nav.attop { background: transparent; border-color: transparent; backdrop-filter: none; }
 .poc-nav.hidden { transform: translateY(-100%); }
-.poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
+.poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: var(--fg); text-decoration: none; letter-spacing: .05em; }
 .poc-mono span { opacity: .5; margin: 0 1px; }
-.poc-links { display: flex; align-items: center; gap: 22px; }
-.poc-links a { color: #c8c8d0; text-decoration: none; font-size: 14px; transition: color .2s; }
-.poc-links a:hover { color: #fff; }
-.poc-kbd { font-size: 11px; color: #9a9aa6; border: 1px solid rgba(255,255,255,.15); border-radius: 6px; padding: 3px 7px; }
+.poc-links { display: flex; align-items: center; gap: 20px; }
+.poc-links a { color: var(--muted); text-decoration: none; font-size: 14px; transition: color .2s; }
+.poc-links a:hover { color: var(--fg); }
+.poc-theme { background: none; border: none; color: var(--muted); font-size: 15px; cursor: pointer; line-height: 1; padding: 2px; }
+.poc-theme:hover { color: var(--fg); }
+.poc-kbd { font-size: 11px; color: var(--muted2); border: 1px solid var(--pill); border-radius: 6px; padding: 3px 7px; background: none; cursor: pointer; }
+.poc-kbd:hover { color: var(--fg); }
 
-.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
+.poc-trail { position: absolute; top: 0; left: 0; z-index: 1; pointer-events: none; color: var(--trail); }
+.trail-faint { stroke: var(--faint); }
 .poc-content { position: relative; z-index: 2; max-width: 880px; margin: 0 auto; padding: 0 24px; }
 
 .reveal { opacity: 0; transform: translateY(22px); transition: opacity .7s cubic-bezier(.2,.7,.2,1), transform .7s cubic-bezier(.2,.7,.2,1); }
@@ -260,40 +309,50 @@ header, footer { display: none !important; }
 .poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
 .poc-hero h1 span { display: block; }
-.poc-lede { font-size: clamp(16px, 2.1vw, 20px); color: #c8c8d0; max-width: 54ch; line-height: 1.5; }
+.poc-lede { font-size: clamp(16px, 2.1vw, 20px); color: var(--muted); max-width: 54ch; line-height: 1.5; }
 .poc-metrics { display: flex; gap: 40px; margin: 36px 0 32px; flex-wrap: wrap; }
 .m-metric { display: flex; flex-direction: column; }
 .m-num { font-size: clamp(26px, 4vw, 38px); font-weight: 600; letter-spacing: -.01em; }
-.m-label { font-size: 13px; color: #9a9aa6; margin-top: 4px; }
+.m-label { font-size: 13px; color: var(--muted2); margin-top: 4px; }
 .poc-cta { display: flex; gap: 14px; flex-wrap: wrap; }
 .btn { display: inline-block; padding: 11px 20px; border-radius: 10px; font-size: 14px; font-weight: 500; text-decoration: none; transition: transform .15s ease, filter .15s ease; }
 .btn:hover { transform: translateY(-2px); }
 .btn.primary { background: ${VIOLET}; color: #fff; }
 .btn.primary:hover { filter: brightness(1.1); }
-.btn.ghost { color: #e6e6ea; border: 1px solid rgba(255,255,255,.2); }
+.btn.ghost { color: var(--fg); border: 1px solid var(--pill); }
 
 .poc-sec { padding: 12vh 0; }
 .poc-sec h2 { font-size: clamp(24px, 3.5vw, 34px); font-weight: 600; letter-spacing: -.01em; margin: 0 0 24px; }
-.poc-prose { font-size: clamp(16px, 2vw, 19px); color: #c8c8d0; max-width: 60ch; line-height: 1.6; }
+.poc-prose { font-size: clamp(16px, 2vw, 19px); color: var(--muted); max-width: 60ch; line-height: 1.6; }
 .poc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
-.poc-ach { background: rgba(14,16,22,.55); border: 1px solid rgba(255,255,255,.08); border-radius: 14px; padding: 20px 22px; backdrop-filter: blur(6px); }
+.poc-ach { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 20px 22px; backdrop-filter: blur(6px); }
 .ach-outcome { margin: 0 0 14px; font-size: 16px; line-height: 1.4; }
 .ach-skills { display: flex; flex-wrap: wrap; gap: 7px; }
-.pill { font-size: 11.5px; color: #b9b9c4; border: 1px solid rgba(255,255,255,.14); border-radius: 999px; padding: 3px 10px; }
-.poc-now { display: flex; flex-wrap: wrap; align-items: center; gap: 18px; margin-top: 22px; padding-top: 20px; border-top: 1px solid rgba(255,255,255,.08); }
-.now-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .12em; font-size: 11px; color: #8a8a96; }
-.now-item { font-size: 13.5px; color: #b9b9c4; }
-.now-item strong { color: #ededf2; font-weight: 600; }
+.pill { font-size: 11.5px; color: var(--muted); border: 1px solid var(--pill); border-radius: 999px; padding: 3px 10px; }
+.poc-now { display: flex; flex-wrap: wrap; align-items: center; gap: 18px; margin-top: 22px; padding-top: 20px; border-top: 1px solid var(--border); }
+.now-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .12em; font-size: 11px; color: var(--muted2); }
+.now-item { font-size: 13.5px; color: var(--muted); }
+.now-item strong { color: var(--fg); font-weight: 600; }
 .poc-bullets { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 16px; max-width: 64ch; }
-.poc-bullets li { position: relative; padding-left: 20px; color: #c8c8d0; line-height: 1.5; }
-.poc-bullets li::before { content: "—"; position: absolute; left: 0; color: #7b7b88; }
-.poc-inline { margin-top: 22px; font-size: 14px; color: #9a9aa6; }
-.poc-inline a { color: ${TRAIL}; text-decoration: underline; text-underline-offset: 3px; }
+.poc-bullets li { position: relative; padding-left: 20px; color: var(--muted); line-height: 1.5; }
+.poc-bullets li::before { content: "—"; position: absolute; left: 0; color: var(--muted2); }
+.poc-inline { margin-top: 22px; font-size: 14px; color: var(--muted2); }
+.poc-inline a { color: var(--trail); text-decoration: underline; text-underline-offset: 3px; }
 .poc-cal { display: grid; grid-template-columns: repeat(20, 1fr); gap: 5px; max-width: 540px; }
-.cell { aspect-ratio: 1; border-radius: 3px; background: ${TRAIL}; }
+.cell { aspect-ratio: 1; border-radius: 3px; background: var(--trail); }
 .poc-contact { min-height: 80vh; display: flex; flex-direction: column; justify-content: center; align-items: flex-start; }
 .poc-contact h2 { font-size: clamp(34px, 6vw, 58px); font-weight: 600; letter-spacing: -.02em; margin: 0 0 14px; }
 .poc-contact .btn { margin-top: 22px; }
+
+.cmdk-overlay { position: fixed; inset: 0; z-index: 50; display: flex; align-items: flex-start; justify-content: center; padding-top: 16vh; background: rgba(0,0,0,.5); backdrop-filter: blur(3px); }
+.cmdk { width: min(540px, 92vw); background: var(--card-solid); border: 1px solid var(--border); border-radius: 14px; overflow: hidden; box-shadow: 0 30px 80px rgba(0,0,0,.5); }
+.cmdk input { width: 100%; padding: 16px 18px; background: transparent; border: none; outline: none; color: var(--fg); font-size: 15px; border-bottom: 1px solid var(--border); box-sizing: border-box; }
+.cmdk ul { list-style: none; margin: 0; padding: 6px; max-height: 320px; overflow: auto; }
+.cmdk li { padding: 11px 14px; border-radius: 9px; font-size: 14px; color: var(--muted); cursor: pointer; display: flex; justify-content: space-between; align-items: center; }
+.cmdk li:hover { background: var(--hover); color: var(--fg); }
+.cmdk-hint { font-size: 11px; color: var(--muted2); }
+.cmdk-empty { color: var(--muted2); cursor: default; }
+
 @media (max-width: 640px) { .poc-grid { grid-template-columns: 1fr; } }
 @media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } }
 `;

--- a/app/poc-trail/page.tsx
+++ b/app/poc-trail/page.tsx
@@ -1,52 +1,38 @@
 "use client";
 
 /**
- * THROWAWAY POC v3 — signature "Trail" experience (TSD P0 taste gate).
- * Not production code. v3 adds:
- *  - per-zone BIOME scenery (flat silhouette horizons) + color wash together
- *  - distinct figure PROPS: hiker (hat/pack/camera), climber (helmet/harness/rope),
- *    snowboarder (board/goggles)
- *  - figure pose stays tied to ZONE (not scroll direction) — intentional.
- *  - reduced-motion -> static complete trail, no idle bob
+ * THROWAWAY POC v4 — signature "Trail" experience (TSD P0 taste gate).
+ * Back to the clean v1 aesthetic (user verdict: scenery/figure read childish).
+ *  - abstract glowing-dot marker rides the drawn switchback trail
+ *  - color wash per zone (mood), meaning carried by TYPOGRAPHY (copy/labels)
+ *  - kept the clean structural wins: sticky nav + real content cards
+ *  - NO scenery, NO figure. Restraint = senior.
+ *  - reduced-motion -> static complete trail
  */
 
 import { useEffect, useRef, useState } from "react";
 
-// Option 2 (expedition day): approach -> crux -> descent.
+// Option 2 (expedition day) — order still open; meaning is in the words.
 const ZONES = [
   {
     key: "approach", sport: "Hike", label: "The approach",
     heading: "About",
     body: "Platform engineer who likes hard problems and clean abstractions. The work — and the mountains — both start with the approach.",
-    accent: "#6f9e6f", bg: "#0a120d", sky: "#0f1d14",
+    accent: "#6f9e6f", bg: "#0a120d",
   },
   {
     key: "crux", sport: "Climb", label: "The crux",
     heading: "The work",
     body: "Internal developer platforms for thousands of engineers — CI/CD, DevOps intelligence, and AI-native tooling. The crux: make shipping safe and fast.",
-    accent: "#9b7cff", bg: "#120e1c", sky: "#1b1430",
+    accent: "#9b7cff", bg: "#120e1c",
   },
   {
     key: "descent", sport: "Snowboard", label: "The descent",
     heading: "Off the clock",
     body: "Homelab, local-LLM routing, AI-native tooling with Claude Code — and when the screens are off, snowboarding through the woods.",
-    accent: "#6fa8d6", bg: "#0a1019", sky: "#101b2b",
+    accent: "#6fa8d6", bg: "#0a1019",
   },
 ] as const;
-
-// Flat silhouette horizons (viewBox 1440x400, stretched full-width, bottom-anchored)
-const SCENERY = {
-  far: "M0 400 L0 230 L260 130 L520 210 L780 110 L1040 200 L1300 120 L1440 180 L1440 400 Z",
-  // forest: low hill + jagged treeline
-  approach:
-    "M0 400 L0 320 L40 270 L70 312 L110 255 L150 306 L195 250 L235 300 L280 246 L320 300 L370 256 L410 305 L460 260 L500 305 L555 250 L600 300 L650 260 L700 305 L760 250 L810 300 L860 258 L910 302 L965 250 L1010 300 L1065 258 L1110 302 L1165 252 L1210 300 L1265 258 L1310 300 L1365 255 L1410 300 L1440 282 L1440 400 Z",
-  // rock: tall sharp alpine spires
-  crux:
-    "M0 400 L0 260 L120 90 L200 205 L300 60 L400 195 L520 42 L640 205 L760 80 L880 210 L1000 70 L1120 205 L1240 100 L1360 210 L1440 150 L1440 400 Z",
-  // snow: smooth rolling ridge
-  descent:
-    "M0 400 L0 300 C 240 250, 420 232, 620 262 C 760 282, 820 182, 980 202 C 1140 222, 1260 300, 1440 290 L1440 400 Z",
-};
 
 function buildSwitchbackPath(h: number, w: number) {
   const cx = w / 2;
@@ -65,66 +51,6 @@ function buildSwitchbackPath(h: number, w: number) {
     xprev = x;
   }
   return d;
-}
-
-function Figure({ zone, color }: { zone: number; color: string }) {
-  const s = { stroke: color, strokeWidth: 1.5, strokeLinecap: "round" as const, strokeLinejoin: "round" as const, fill: "none" };
-  const cap = { fill: color, stroke: "none" };
-  if (zone === 0) {
-    // hiker: hat, daypack, camera, trekking pole
-    return (
-      <g {...s}>
-        <circle cx={0} cy={-11} r={2.3} {...cap} />
-        <path d="M-4 -13 L4 -13" /> {/* hat brim */}
-        <path d="M-2.5 -13 Q0 -17 2.5 -13" {...cap} /> {/* hat crown */}
-        <rect x={-6.5} y={-9} width={4} height={8} rx={1.5} fill={color} fillOpacity={0.5} stroke="none" /> {/* pack */}
-        <rect x={1.2} y={-5} width={3} height={2.3} rx={0.5} /> {/* camera */}
-        <path d="M0 -8 L0 0" />
-        <path d="M0 0 L-4 7" />
-        <path d="M0 0 L4 6" />
-        <path d="M0 -6 L5 -3" />
-        <path d="M5 -3 L6 8" /> {/* pole */}
-      </g>
-    );
-  }
-  if (zone === 1) {
-    // climber: helmet, harness, trailing rope, reaching pose, rock edge
-    return (
-      <g {...s}>
-        <path d="M9 -16 L9 10" strokeOpacity={0.3} /> {/* rock edge */}
-        <circle cx={0} cy={-11} r={2.3} {...cap} />
-        <path d="M-3 -11 Q0 -15.5 3 -11 Z" {...cap} /> {/* helmet */}
-        <path d="M0 -8 L-1 0" />
-        <path d="M0 -7 L5 -14" /> {/* reaching arm */}
-        <path d="M-1 -5 L-5 -2" /> {/* low arm */}
-        <rect x={-3.5} y={-1} width={7} height={2} rx={0.7} fill={color} fillOpacity={0.6} stroke="none" /> {/* harness */}
-        <path d="M-1 0 L-4 8" />
-        <path d="M-1 0 L3 6" />
-        <path d="M0 1 C 6 6, -2 13, 4 21" strokeOpacity={0.7} /> {/* rope */}
-      </g>
-    );
-  }
-  // snowboarder: board, goggles, arms out
-  return (
-    <g {...s}>
-      <path d="M-9 8 L9 6" strokeWidth={2.4} />
-      <path d="M-3 7 L-1 0" />
-      <path d="M4 6 L1 0" />
-      <path d="M0 0 L1 -7" />
-      <circle cx={1} cy={-10} r={2.3} {...cap} />
-      <path d="M-1 -10.5 L3.2 -10.7" strokeWidth={1.4} /> {/* goggles */}
-      <path d="M0 -4 L-7 -6" />
-      <path d="M0 -4 L8 -3" />
-    </g>
-  );
-}
-
-function Horizon({ d, fill, opacity, z }: { d: string; fill: string; opacity: number; z: number }) {
-  return (
-    <svg className="poc-horizon" viewBox="0 0 1440 400" preserveAspectRatio="none" aria-hidden style={{ zIndex: z }}>
-      <path d={d} fill={fill} style={{ transition: "opacity 700ms ease" }} opacity={opacity} />
-    </svg>
-  );
 }
 
 export default function PocTrail() {
@@ -191,25 +117,14 @@ export default function PocTrail() {
         </div>
       </nav>
 
-      {/* sky/color wash */}
-      <div className="poc-bg" style={{ background: `linear-gradient(180deg, ${z.sky} 0%, ${z.bg} 45%, #05060a 100%)` }} aria-hidden />
-
-      {/* biome scenery — color + scenery together */}
-      <div className="poc-scenery" aria-hidden>
-        <Horizon d={SCENERY.far} fill="#ffffff" opacity={0.035} z={1} />
-        <Horizon d={SCENERY.approach} fill="#0e1f16" opacity={zone === 0 ? 1 : 0} z={2} />
-        <Horizon d={SCENERY.crux} fill="#1a1330" opacity={zone === 1 ? 1 : 0} z={2} />
-        <Horizon d={SCENERY.descent} fill="#152233" opacity={zone === 2 ? 1 : 0} z={2} />
-      </div>
+      <div className="poc-bg" style={{ background: `radial-gradient(120% 80% at 50% 0%, ${z.bg} 0%, #05060a 70%)` }} aria-hidden />
 
       <svg className="poc-trail" width={dims.w} height={dims.h} viewBox={`0 0 ${dims.w} ${dims.h}`} fill="none" aria-hidden>
         <path d={d} stroke="#ffffff" strokeOpacity={0.06} strokeWidth={2.5} />
         <path ref={pathRef} d={d} stroke={z.accent} strokeWidth={3} strokeLinecap="round" style={{ transition: "stroke 600ms ease" }} />
         <g ref={markerRef} style={{ opacity: 0 }}>
-          <circle r={15} fill={z.accent} fillOpacity={0.12} />
-          <g className={reduced ? "" : "poc-fig"}>
-            <g transform="scale(1.3)"><Figure zone={zone} color={z.accent} /></g>
-          </g>
+          <circle r={11} fill={z.accent} fillOpacity={0.2} />
+          <circle r={5} fill={z.accent} />
         </g>
       </svg>
 
@@ -245,10 +160,6 @@ const css = `
 header, footer { display: none !important; }
 .poc-root { position: relative; color: #f2f2f5; font-family: var(--font-geist, ui-sans-serif, system-ui); }
 .poc-bg { position: fixed; inset: 0; z-index: 0; transition: background 700ms ease; }
-.poc-scenery { position: fixed; left: 0; right: 0; bottom: 0; height: 46vh; z-index: 1; pointer-events: none; }
-.poc-horizon { position: absolute; left: 0; bottom: 0; width: 100%; height: 100%; }
-.poc-fig { animation: bob 2.4s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
-@keyframes bob { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(-3px);} }
 
 .poc-nav { position: fixed; top: 0; left: 0; right: 0; z-index: 10; display: flex; align-items: center; justify-content: space-between; padding: 16px 28px; background: rgba(8,9,13,.5); backdrop-filter: blur(10px); border-bottom: 1px solid rgba(255,255,255,.06); }
 .poc-mono { font-family: var(--font-silkscreen, monospace); font-size: 18px; color: #fff; text-decoration: none; letter-spacing: .05em; }
@@ -258,8 +169,8 @@ header, footer { display: none !important; }
 .poc-links a:hover { color: #fff; }
 .poc-kbd { font-size: 11px; color: #9a9aa6; border: 1px solid rgba(255,255,255,.15); border-radius: 6px; padding: 3px 7px; }
 
-.poc-content { position: relative; z-index: 3; max-width: 720px; margin: 0 auto; padding: 0 24px; }
-.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 2; pointer-events: none; }
+.poc-content { position: relative; z-index: 2; max-width: 720px; margin: 0 auto; padding: 0 24px; }
+.poc-trail { position: absolute; top: 0; left: 50%; transform: translateX(-50%); z-index: 1; pointer-events: none; }
 .poc-hero { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; }
 .poc-eyebrow { font-family: var(--font-silkscreen, monospace); text-transform: uppercase; letter-spacing: .15em; font-size: 12px; opacity: .85; margin: 0 0 16px; }
 .poc-hero h1 { font-size: clamp(38px, 7vw, 72px); line-height: 1.02; margin: 0 0 20px; font-weight: 600; letter-spacing: -.02em; }
@@ -268,10 +179,10 @@ header, footer { display: none !important; }
 @keyframes cue { 0%,100%{ transform: translateY(0);} 50%{ transform: translateY(8px);} }
 .poc-zone { min-height: 100vh; display: flex; align-items: center; }
 .poc-zone:nth-child(odd) .poc-card { margin-left: auto; }
-.poc-card { background: rgba(12,14,20,.62); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
+.poc-card { background: rgba(12,14,20,.55); backdrop-filter: blur(8px); border: 1px solid; border-radius: 16px; padding: 28px 30px; max-width: 380px; box-shadow: 0 20px 60px rgba(0,0,0,.4); }
 .poc-card h2 { font-size: clamp(26px, 4vw, 38px); margin: 0 0 12px; font-weight: 600; letter-spacing: -.01em; }
 .poc-card p { margin: 0; color: #c2c2cc; line-height: 1.5; }
 .poc-summit { min-height: 100vh; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; }
 .poc-summit h2 { font-size: clamp(34px, 6vw, 60px); margin: 0 0 16px; font-weight: 600; letter-spacing: -.02em; }
-@media (prefers-reduced-motion: reduce) { .poc-scrollcue, .poc-fig { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .poc-scrollcue { animation: none; } }
 `;

--- a/components/count-up.tsx
+++ b/components/count-up.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Counts a metric up from 0 to its value when it scrolls into view.
+ * Preserves the "+" / formatting suffix. Renders the final value immediately
+ * under prefers-reduced-motion (and never on the server, to avoid mismatch).
+ */
+export default function CountUp({ value }: { value: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const [disp, setDisp] = useState(value);
+
+  useEffect(() => {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const num = parseInt(value.replace(/[^0-9]/g, ""), 10);
+    if (!num) return;
+    const suffix = value.replace(/[0-9,]/g, "");
+    setDisp("0" + suffix);
+    const el = ref.current;
+    if (!el) return;
+    let done = false;
+    const io = new IntersectionObserver(
+      (entries) => {
+        if (!entries[0].isIntersecting || done) return;
+        done = true;
+        const start = performance.now();
+        const tick = (t: number) => {
+          const p = Math.min((t - start) / 1200, 1);
+          setDisp(Math.round(num * (1 - Math.pow(1 - p, 3))).toLocaleString() + suffix);
+          if (p < 1) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+      },
+      { threshold: 0.6 }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [value]);
+
+  return <span ref={ref}>{disp}</span>;
+}

--- a/components/trail-thread.tsx
+++ b/components/trail-thread.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Signature "trail thread" — an abstract violet line in the left gutter that
+ * draws as you scroll, with a marker that rides it. Decorative only: lives in
+ * the margin (never behind text), themes via .text-primary-color (currentColor),
+ * and renders fully-drawn + static under prefers-reduced-motion. Hidden on
+ * narrow viewports where there's no gutter.
+ */
+function buildPath(h: number) {
+  const ax = 24, amp = 14, top = 104;
+  const rest = h - top, n = Math.max(4, Math.round(rest / 360)), step = rest / n;
+  let xprev = ax, y = top, d = `M ${ax} ${top}`;
+  for (let i = 1; i <= n; i++) {
+    const ny = top + i * step, x = i % 2 ? ax + amp : ax - amp;
+    d += ` C ${xprev} ${y + step * 0.5}, ${x} ${ny - step * 0.5}, ${x} ${ny}`;
+    xprev = x; y = ny;
+  }
+  return d;
+}
+
+export default function TrailThread() {
+  const pathRef = useRef<SVGPathElement>(null);
+  const markerRef = useRef<SVGGElement>(null);
+  const [dims, setDims] = useState({ h: 0, w: 0 });
+  const [d, setD] = useState("");
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    setReduced(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    const measure = () => {
+      const h = document.documentElement.scrollHeight;
+      setDims({ h, w: window.innerWidth });
+      setD(buildPath(h));
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    // re-measure after async content (e.g. the GitHub calendar) grows the page
+    const t1 = setTimeout(measure, 700);
+    const t2 = setTimeout(measure, 1800);
+    return () => {
+      window.removeEventListener("resize", measure);
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, []);
+
+  useEffect(() => {
+    const path = pathRef.current;
+    if (!path || !d) return;
+    const total = path.getTotalLength();
+    path.style.strokeDasharray = `${total}`;
+    path.style.strokeDashoffset = reduced ? "0" : `${total}`;
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      const el = document.scrollingElement || document.documentElement;
+      const max = el.scrollHeight - el.clientHeight;
+      const p = max > 0 ? Math.min(Math.max(el.scrollTop / max, 0), 1) : 0;
+      if (!reduced) path.style.strokeDashoffset = `${total * (1 - p)}`;
+      const pt = path.getPointAtLength((reduced ? 1 : p) * total);
+      if (markerRef.current) {
+        markerRef.current.setAttribute("transform", `translate(${pt.x} ${pt.y})`);
+        markerRef.current.style.opacity = reduced ? "0" : "1";
+      }
+    };
+    const onScroll = () => { if (!raf) raf = requestAnimationFrame(update); };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => { window.removeEventListener("scroll", onScroll); if (raf) cancelAnimationFrame(raf); };
+  }, [d, reduced]);
+
+  if (dims.w < 768) return null; // no gutter on mobile
+
+  return (
+    <svg
+      aria-hidden
+      className="absolute top-0 left-0 z-0 pointer-events-none text-primary-color"
+      width={dims.w}
+      height={dims.h}
+      viewBox={`0 0 ${dims.w} ${dims.h}`}
+      fill="none"
+    >
+      <path d={d} stroke="currentColor" strokeOpacity={0.12} strokeWidth={2} />
+      <path ref={pathRef} d={d} stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" />
+      <g ref={markerRef} style={{ opacity: 0 }}>
+        <circle r={9} fill="currentColor" fillOpacity={0.15} />
+        <circle r={4} fill="currentColor" />
+      </g>
+    </svg>
+  );
+}

--- a/docs/tsd-signature-experience.md
+++ b/docs/tsd-signature-experience.md
@@ -1,0 +1,185 @@
+# TSD: brignano.io Signature Homepage Experience ("The Trail")
+
+| | |
+|---|---|
+| **Status** | Draft — awaiting approval |
+| **Author** | Anthony Brignano |
+| **Date** | 2026-06-08 |
+| **Repos** | `brignano.io` (app only) |
+| **Target release** | v4.0 (signature experience) |
+| **Related** | [tsd-site-modernization.md](./tsd-site-modernization.md) (evolves §10.2 motif, reuses §10.3 accent, builds on §5.1 animation system) · [tsd-blog.md](./tsd-blog.md) |
+
+---
+
+## 1. Summary
+
+Give the homepage **one memorable signature interaction** that makes the site unmistakably *Anthony* — without sacrificing the speed, accessibility, or senior/professional read the site depends on. A single continuous **trail / ridgeline** threads vertically through the homepage and **draws itself as the user scrolls**, passing through three ambient altitude zones mapped to the outdoor-life progression — **hiking → snowboarding → climbing** — which doubles as a quiet metaphor for the career arc (foundations → momentum → summit / what's next).
+
+The through-line is the **unifying theme** that ties the two halves of the identity together: the platform work is already framed as *"paved roads for engineers"* (modernization §5.5b); the personal life is literally *trails*. The site's metaphor becomes **the climb** — and nobody else has *this* trail. Uniqueness comes from the authentic narrative, not from rendering tech.
+
+Built with **SVG + CSS + a small scroll-progress hook — no WebGL, no scroll-jacking, no heavy dependencies** — so it fits the static export, stays within the Lighthouse budget, and degrades to a clean static page under `prefers-reduced-motion`.
+
+## 2. Background / problem statement
+
+The current homepage is solid but **reads as a conventional portfolio template**: a traditional top nav and a sequence of well-built but static sections with no through-line or moment of delight. There is nothing that makes a visitor remember *this* site specifically, and nothing that surfaces the personality (outdoors, range, taste) behind the résumé. The goal is to reach the tier of personal sites that get cited as exemplary — **distinctive and custom, not template-driven** — while staying appropriate for an audience that includes recruiters and CIO/CTO/CEO.
+
+**Constraints inherited (non-negotiable):**
+- Static export (`output: "export"`), Vercel, Next 16 / React 19, Tailwind v4.
+- Lighthouse targets from modernization §4: **Performance ≥ 95, Accessibility 100**, no contrast failures.
+- Existing animation contract (modernization §5.1): content is **visible by default**; motion is progressive enhancement; `prefers-reduced-motion` renders the final state with no transforms.
+- Low maintenance burden (personal site, self-maintained).
+
+## 3. Goals / non-goals
+
+**Goals**
+- One **signature, memorable** homepage interaction that is authentically personal.
+- Surface life outside coding (hiking/snowboarding/climbing) as an **ambient journey**, with professional content kept as the substance.
+- Modernize the *feel* of navigation away from a generic top bar (§5.6) without losing obvious wayfinding.
+- Preserve all current SEO, structured data, CSP, content, and the Lighthouse budget.
+- Fully usable and coherent **without** the visual layer (content-first; motion is enhancement).
+
+**Non-goals (this TSD)**
+- **Scroll-jacking / scroll hijacking** of any kind. Native scroll only — the trail responds to scroll, never controls it.
+- WebGL / 3D / heavy animation libraries as the primary mechanism (Direction C — explicitly rejected as style-over-substance for this audience).
+- Re-architecting content/IA, the blog, `/resume`, or `/coding` (separate efforts).
+- A redesign of the visual identity beyond evolving the already-decided motif + accent.
+
+## 4. Audience & success criteria
+
+| Audience | What they need | We win when… |
+|---|---|---|
+| Peers / hiring engineers | Evidence of taste + craft | The interaction reads as "tasteful and well-built," not gimmicky |
+| Recruiters | Fast credibility, easy wayfinding | Obvious nav + content still scannable in seconds |
+| CIO/CTO/CEO | Senior signal, no flash-over-substance | Calm, fast, professional; the personality reads as confidence |
+| Returning peers / "portfolio roundups" | A reason to remember + share | The trail is distinctive enough to be the thing people mention |
+
+**Measurable success**
+- Lighthouse (mobile + desktop): **Performance ≥ 95, Accessibility 100**; CLS ≈ 0 from the trail layer.
+- `prefers-reduced-motion`: trail renders **static and complete**, zero scroll-linked motion, all content visible.
+- No scroll-jank: trail updates stay on the compositor (transform/opacity only); main thread not blocked on scroll.
+- Works at 375×812 (mobile) — the signature is *felt*, not broken or hidden.
+- Net added JS for the experience is **small** (target: no heavy animation dep; vanilla hook + CSS).
+- The page is fully understandable with the SVG layer removed (content-first check).
+
+## 5. Proposed design
+
+### 5.1 Concept & narrative mapping
+
+A single **persistent trail layer** sits behind the homepage content as a vertical spine (edge-anchored on desktop, simplified on mobile). As the user scrolls top → bottom, the trail **draws** from trailhead to summit, and the ambient backdrop shifts through three zones. **Professional content is foregrounded as the substance; the outdoor zones are the connective tissue and personality**, not a literal "my career is a mountain" billboard.
+
+| Scroll zone | Outdoor | Career sub-text | Maps to existing section(s) |
+|---|---|---|---|
+| **Base — forest** | Hiking | Foundations / who I am | Hero (trailhead) → About |
+| **Mid — slopes** | Snowboarding | Momentum / the platform work | Highlights → Current Role |
+| **Summit — ridge** | Climbing | Current / what's next | Open-source activity → Contact ("Let's build something" = the peak) |
+
+No section reordering is required — the existing top-to-bottom order already reads base → summit. Hero is the trailhead; the final CTA is the summit payoff.
+
+### 5.2 Visual language
+
+- **The trail line:** a restrained, line-art path — a stylized **topographic ridgeline / contour** rather than a literal cartoon mountain. This *evolves* the "paved road" motif decided in modernization §10.2 into a "trail" (same idea, richer story). Concentrated and deliberate — the site's signature, like the Silkscreen accent: used once, well.
+- **Zone ambiance:** subtle, low-contrast backdrop hue shift between zones (cool forest → slope blue → **summit indigo/violet**, paying off the accent decided in modernization §10.3). Shifts must stay subtle enough to preserve WCAG AA text contrast in both themes.
+- **Waypoints (Phase 2):** at each zone boundary, a small line-art glyph (hiker / snowboarder / climber) reveals as the trail passes — the only illustration on the site, kept minimal and on-theme. Decorative (`aria-hidden`).
+- **Restraint rule:** if a flourish doesn't serve the trail metaphor or reveal personality, it's cut. One signature, not ten effects.
+
+### 5.3 Technical approach
+
+- **Trail = inline SVG path** in a fixed/sticky decorative layer behind content. Tiny payload; crisp at any DPI; theme-able via `currentColor`/CSS vars.
+- **Draw on scroll = `stroke-dasharray` + `stroke-dashoffset`** driven by a scroll-progress value (0→1). Baseline mechanism: a small `useScrollProgress` hook (scroll listener throttled with `requestAnimationFrame`) writing a CSS custom property `--trail-progress`; the SVG offset and zone backdrops read that variable. **Compositor-only** properties (transform/opacity/stroke-dashoffset) — no layout thrash.
+- **Progressive enhancement:** where supported, use **CSS scroll-driven animations** (`animation-timeline: scroll()`) so the draw runs off the main thread with *zero* JS; fall back to the rAF hook elsewhere. (Browser support is uneven as of this writing — the JS hook is the reliable baseline; CSS scroll-timeline is a later enhancement, not a dependency.)
+- **No WebGL, no GSAP/ScrollMagic.** Evaluate whether even a motion lib (e.g. `motion`/Framer) is warranted — **default to vanilla + CSS** to protect the bundle and stay consistent with the custom `ScrollReveal` (which already replaced AOS). Any dep must justify its bundle cost in the P0 spike.
+- **Static-export safe:** everything renders at build; the trail is a client component that enhances already-present, server-rendered content.
+
+### 5.4 Accessibility & motion (content-first)
+
+- **`prefers-reduced-motion: reduce` → trail renders fully drawn and static**, no scroll-linked drawing, no parallax, no zone transitions beyond a static backdrop. Mirrors the modernization §5.1 contract.
+- The trail layer is **decorative**: `aria-hidden="true"` / `role="presentation"`. The narrative is conveyed by real text content; **removing the SVG must not remove meaning**.
+- **No scroll-jacking, no scroll snapping that traps the user.** Native scroll velocity preserved; keyboard scroll, Page Down, and screen-reader virtual cursor all behave normally.
+- Focus order and tab navigation unaffected by the decorative layer.
+- Maintain AA contrast across all zone backdrops, light and dark.
+
+### 5.5 Mobile strategy
+
+- The trail **simplifies, it does not disappear**: thinner spine anchored to one edge (or centered), reduced waypoint detail, zone ambiance retained.
+- No effect may push the hero's primary CTA below the fold at 375×812 (modernization §4 carry-over).
+- Scroll performance verified on a mid-tier device profile; if the rAF hook ever costs frames on mobile, the trail falls back to a static drawn state there.
+
+### 5.6 Navigation refresh (addresses the "traditional topnav" gripe)
+
+Keep obvious wayfinding (recruiters/execs/a11y need it) but make nav part of the signature rather than a generic bar:
+
+- **Refine, don't remove, the header:** minimal, sticky, quiet.
+- **Trail-anchored progress + section markers:** the trail doubles as a scroll-progress indicator; waypoints are clickable to jump to sections — nav *is* the trail.
+- **⌘K command palette (peer-craft signal):** fast keyboard navigation + actions (résumé, coding, blog, contact, theme). Reuse `@headlessui/react` (already a dep) for an accessible dialog; no new heavy dep. Strong "modern senior dev" signal that costs little.
+
+### 5.7 Relationship to the modernization TSD
+
+This **evolves**, not contradicts, the prior decisions:
+- §10.2 "restrained paved-road motif" → becomes the **trail through-line** (same restraint principle, fuller narrative).
+- §10.3 electric indigo/violet accent → becomes the **summit color**, giving the accent a narrative reason to exist.
+- §5.1 animation contract (visible-by-default, reduced-motion-safe) → **reused verbatim** as the foundation.
+
+## 6. Phasing
+
+```mermaid
+graph LR
+    P0["P0 — Spike / prototype<br/>coded trail spine on a branch<br/>GUT-CHECK: tasteful, not cheesy?<br/>+ perf/a11y proof"] --> P1["P1 — Trail spine + zones<br/>SVG draw-on-scroll + ambiance<br/>reduced-motion + mobile"]
+    P1 --> P2["P2 — Personality + nav<br/>waypoint glyphs + narrative copy<br/>+ ⌘K palette"]
+    P2 -.fast-follow.-> P3["P3 — Polish<br/>CSS scroll-timeline PE<br/>subtle parallax, micro-detail"]
+```
+
+| Phase | Scope | Risk | Gate |
+|---|---|---|---|
+| **P0** | §5.3 spike, taste gate | High (taste) | **A real coded prototype to look at and approve before committing.** Kill/redirect here if it reads gimmicky. |
+| **P1** | §5.1–5.5 core | Med | Trail draws, zones shift, passes Lighthouse + reduced-motion + mobile |
+| **P2** | §5.2 waypoints, §5.6 nav | Low | Personality + nav refresh shipped |
+| **P3** | §5.3 PE, polish | Low | Optional enhancements once core is proven |
+
+**P0 is a hard gate.** This design lives or dies on taste, which cannot be specified — only seen. Build a throwaway prototype, look at it on real devices, and only proceed if it clears the "tasteful, unmistakably me, not cheesy" bar.
+
+## 7. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Metaphor reads as cheesy / forced** | P0 taste gate with a real prototype; keep professional content as substance and the trail as ambient connective tissue; line-art restraint, not literal cartoon mountain. |
+| Performance regression (scroll handler jank) | Compositor-only props; rAF throttle; CSS scroll-timeline where available; static fallback on weak devices; Lighthouse ≥95 gate before merge. |
+| Accessibility regression | Decorative `aria-hidden`; reduced-motion static path; no scroll-jack/snap-trap; content-first check (page works with SVG removed). |
+| Mobile breakage | Simplified-not-hidden trail; CTA-above-fold check; device-profile scroll test. |
+| Scope creep toward Direction C | Non-goals fence WebGL/3D out; each flourish must serve the metaphor or be cut. |
+| Maintenance burden | Vanilla + CSS, no heavy deps; single self-contained trail component sourced from constants where possible. |
+| Conflicts with in-flight modernization work | This TSD explicitly evolves §10.2/§10.3/§5.1; sequence after those land. |
+
+## 8. Verification plan
+
+- Coded P0 prototype reviewed on desktop + mobile, light + dark, before P1 begins.
+- Lighthouse (mobile + desktop) meets §4 targets; CLS from the trail ≈ 0.
+- `prefers-reduced-motion`: fully drawn static trail, no scroll-linked motion, all content visible.
+- Scroll performance: no dropped frames on a mid-tier mobile profile; main thread not blocked.
+- Content-first check: disable the SVG layer → page is complete and coherent.
+- `next build` (static export) succeeds; bundle delta for the experience within target.
+- ⌘K palette: keyboard-operable, focus-trapped, screen-reader-announced (Headless UI dialog semantics).
+- Nav wayfinding still obvious to a first-time visitor (quick hallway test).
+
+## 9. Decisions & open questions
+
+**Resolved**
+1. **Direction:** ✅ **B — Trail through-line** (calm/fast baseline + one signature scroll narrative). Direction C (WebGL cinematic) rejected; Direction A (calm craft) is the floor and is included.
+2. **Theme:** ✅ **The climb / trail** — unifies "paved roads for engineers" (work) with literal outdoor trails (life); evolves modernization §10.2 motif.
+3. **Tech:** ✅ **SVG + CSS + small scroll-progress hook; no WebGL, no scroll-jacking, no heavy deps.** §5.3
+4. **Motion contract:** ✅ reduced-motion → static complete trail; decorative/`aria-hidden`; content-first. §5.4
+5. **Nav:** ✅ keep + refine header, add trail-anchored progress and **⌘K palette**; do not remove conventional nav. §5.6
+
+**Open (resolve at/around P0 — not approval-blocking)**
+- **Trail visual style:** topographic contour vs single ridgeline vs dotted path — decide from P0 prototype variants.
+- **Waypoint treatment:** line-art figures (hiker/boarder/climber) vs abstract markers — taste call at P2.
+- **Dependency:** confirm vanilla+CSS is sufficient vs a minimal motion lib — settle in the P0 spike on bundle evidence.
+- **Asset creation:** hand-draw / AI-generate / source the line-art trail + glyphs — decide once style is chosen.
+- **Sequencing vs modernization P1/P2:** confirm this lands after the type/hero/accent work.
+
+## 10. References (taste calibration)
+
+Engineer-portfolio canon to benchmark restraint + craft (none scroll-jack): **brittanychiang.com** (clean senior-dev standard), **joshwcomeau.com** (world-class motion *with* substance), **rauno.me** / **paco.me** / **emilkowal.ski** (craft, restraint, interaction detail). Study what they omit as much as what they include.
+
+---
+
+*Approval = sign-off on §3 goals, §5 design, and the §9 resolved decisions. **P0 (prototype + taste gate) is the first step and is itself a checkpoint** — full build proceeds only after the prototype is approved.*


### PR DESCRIPTION
## What

Draft TSD for the homepage **signature experience** (Direction B, chosen). No implementation — spec for review.

📄 [docs/tsd-signature-experience.md](docs/tsd-signature-experience.md)

## The idea

One memorable interaction that's unmistakably *you*: a continuous **trail/ridgeline** that **draws as you scroll**, threading the homepage through **hiking → snowboarding → climbing** zones — which double as the career arc (foundations → momentum → summit). The through-line unifies the two halves of the identity: platform work = *"paved roads for engineers"*; life = literal *trails*. Theme = **the climb**.

## Principles

- **Restraint + one signature moment**, not ten effects — the tier respected by engineers, not Awwwards scroll-jackers.
- **No scroll-jacking, no WebGL, no heavy deps.** SVG + CSS + a small scroll-progress hook.
- **Content-first / a11y:** decorative layer, `prefers-reduced-motion` → static complete trail, page fully usable with the visuals removed.
- Stays within the existing Lighthouse budget (Perf ≥95 / A11y 100) and the static export.

## Evolves prior decisions

Builds on the modernization TSD: paved-road motif (§10.2) → the trail; indigo/violet accent (§10.3) → the summit color; animation contract (§5.1) reused verbatim.

## Nav refresh

Addresses the "traditional topnav feels bland" gripe: refined sticky header + trail-anchored scroll progress/section markers + a **⌘K command palette** (peer-craft signal, reuses Headless UI). Conventional nav kept for wayfinding/a11y.

## Phasing — note the hard gate

**P0 is a real coded prototype + taste gate.** This design lives or dies on taste, which can't be specced — only seen. We build a throwaway, look at it on real devices, and only proceed if it clears "tasteful, unmistakably me, not cheesy." Then P1 (trail spine + zones) → P2 (waypoints + nav) → P3 (polish).

## Open questions (non-blocking, settled around P0)

Trail visual style · waypoint treatment · vanilla-vs-motion-lib · asset creation · sequencing vs modernization P1/P2.

---

**Approval = sign-off on §3 goals, §5 design, §9 resolved decisions.** P0 (prototype) is itself a checkpoint before full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)