### PR TITLE
feat(home): dedupe badges, clarify build copy, add latest commit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import {
   EnvelopeIcon,
 } from "@heroicons/react/24/outline";
 import GitHubCalendarClient from "@/components/github-calendar-client";
+import LatestCommit from "@/components/latest-commit";
 import HeroMotif from "@/components/hero-motif";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
 import {
@@ -206,6 +207,7 @@ export default function Home() {
                 </li>
               ))}
             </ul>
+            <LatestCommit />
           </div>
         </section>
 
@@ -300,7 +302,7 @@ export default function Home() {
                   A unified developer surface — custom CLI, desktop app, and IDE extensions — with 1,000+ engineers active in the first 90 days.
                 </li>
                 <li>
-                  &ldquo;One build command, any stack&rdquo; — context-aware builds that run identically locally, in CI, or fully remote, on a custom base-image registry.
+                  &ldquo;One build command, any stack&rdquo; — the same command builds any project and runs the same on your laptop, in CI, or on a remote machine. Nothing to set up per project.
                 </li>
                 <li>
                   Real-time DevOps intelligence — an event bus streaming pipeline and CLI/IDE telemetry into AWS, DynamoDB, and Snowflake for ML analysis of developer pain points; upgraded observability (Splunk, Dynatrace) and a live platform health status page with subscribe-able alerts.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -196,16 +196,38 @@ export default function Home() {
               Now building
             </p>
             <ul className="flex flex-wrap gap-x-6 gap-y-2 text-sm dark:text-zinc-400 text-zinc-600">
-              {nowBuilding.map((item) => (
-                <li key={item.label}>
+              {nowBuilding.map((item) => {
+                const label = (
                   <span className="font-medium dark:text-zinc-200 text-zinc-800">
                     {item.label}
-                  </span>{" "}
-                  <span className="dark:text-zinc-500 text-zinc-500">
-                    {item.detail}
                   </span>
-                </li>
-              ))}
+                );
+                return (
+                  <li key={item.label}>
+                    {item.href ? (
+                      <a
+                        href={item.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="group inline-flex items-center gap-1 underline decoration-dotted decoration-zinc-300 dark:decoration-zinc-600 underline-offset-4 hover:decoration-primary-color focus-visible:decoration-primary-color transition-colors"
+                      >
+                        {label}
+                        <span
+                          aria-hidden="true"
+                          className="text-[11px] text-zinc-400 dark:text-zinc-500 transition-transform group-hover:translate-x-0.5"
+                        >
+                          ↗
+                        </span>
+                      </a>
+                    ) : (
+                      label
+                    )}{" "}
+                    <span className="dark:text-zinc-500 text-zinc-500">
+                      {item.detail}
+                    </span>
+                  </li>
+                );
+              })}
             </ul>
             <LatestCommit />
           </div>

--- a/components/latest-commit.tsx
+++ b/components/latest-commit.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchLatestPublicCommit, type LatestCommit as LC } from "@/lib/github";
+
+function timeAgo(iso?: string | null): string {
+  if (!iso) return "";
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.round(diff / 60000);
+  if (m < 1) return "just now";
+  if (m < 60) return `${m}m ago`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h}h ago`;
+  return `${Math.round(h / 24)}d ago`;
+}
+
+/**
+ * Subtle "actively building" signal — latest commit from public repos only
+ * (the day-job platform work is private). Fetched client-side for freshness;
+ * renders nothing if the GitHub call fails so it never breaks the layout.
+ */
+export default function LatestCommit() {
+  const [commit, setCommit] = useState<LC | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      const c = await fetchLatestPublicCommit();
+      if (!c) return;
+      // The events API often omits commit messages; enrich from the commit endpoint.
+      let message = (c.message || "").trim();
+      if (!message && c.repo && c.sha) {
+        try {
+          const res = await fetch(
+            `https://api.github.com/repos/${c.repo}/commits/${c.sha}`
+          );
+          if (res.ok) {
+            const d = await res.json();
+            message = (d?.commit?.message || "").trim();
+          }
+        } catch {
+          /* keep empty; render falls back gracefully */
+        }
+      }
+      if (mounted) setCommit({ ...c, message });
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (!commit) return null;
+
+  const message = (commit.message || "").split("\n")[0];
+  const short =
+    message.length > 64
+      ? `${message.slice(0, 64)}…`
+      : message || "view commit";
+  const repo = commit.repo?.split("/")[1] ?? commit.repo;
+
+  return (
+    <p className="mt-4 text-sm dark:text-zinc-500 text-zinc-500">
+      Latest commit:{" "}
+      <a
+        href={commit.url ?? "#"}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary-color hover:underline"
+      >
+        {short}
+      </a>{" "}
+      <span className="dark:text-zinc-600 text-zinc-400">
+        in {repo}
+        {commit.date ? ` · ${timeAgo(commit.date)}` : ""}
+      </span>
+    </p>
+  );
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -276,13 +276,26 @@ export const achievements: Achievement[] = [
 export interface NowItem {
   label: string;
   detail: string;
+  href?: string;
 }
 
 // Tier 2 — "Now" momentum strip (TSD §5.5b): hands-on, current personal work.
 export const nowBuilding: NowItem[] = [
-  { label: "Homelab", detail: "Proxmox · Docker · Tailscale" },
-  { label: "Local-LLM routing", detail: "Ollama · Open WebUI" },
-  { label: "AI-native tooling", detail: "Claude Code" },
+  {
+    label: "Homelab",
+    detail: "Proxmox · Docker · Tailscale",
+    href: "https://www.github.com/brignano/homelab",
+  },
+  {
+    label: "Local-LLM routing",
+    detail: "Ollama · Open WebUI",
+    href: "https://www.github.com/brignano/homelab",
+  },
+  {
+    label: "AI-native tooling",
+    detail: "Claude Code",
+    href: "https://www.github.com/brignano/ai-tools",
+  },
 ];
 
 export const projects: Project[] = [];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -261,7 +261,7 @@ export const achievements: Achievement[] = [
   },
   {
     outcome: "1,000+ engineers active in the first 90 days",
-    skills: ["Desktop App", "CLI", "Self-service onboarding"],
+    skills: ["Desktop App", "Self-service onboarding"],
   },
   {
     outcome: "One build command, any stack — local, CI, or fully remote",


### PR DESCRIPTION
Small live-homepage improvements (separate from the signature-experience POC). All three came out of a content review.

## Changes

1. **Dedupe skill badges** — removed the redundant `CLI` pill from the "1,000+ active" tile; the platform tile already carries `Custom CLI`. ([constants.ts](lib/constants.ts))
2. **Plainer build copy** — the current-role bullet was jargon-heavy (an intern flagged it as unclear). Rewrote it dropping "context-aware" and "base-image registry":
   > "One build command, any stack" — the same command builds any project and runs the same on your laptop, in CI, or on a remote machine. Nothing to set up per project.
3. **Live "Latest commit" line** — a subtle "actively building" signal under the Now-building strip. New [`<LatestCommit />`](components/latest-commit.tsx):
   - **Public repos only** (the day-job LDP work is private) via existing `fetchLatestPublicCommit()`.
   - Fetched **client-side** for freshness; enriches the message from the commit endpoint (the events API omits it).
   - Renders **nothing on failure** — never breaks the layout.

## Verification

- Dev preview: badges deduped, new build line renders, latest-commit shows message + repo + time-ago + working commit link.
- `tsc`: no new errors (the one pre-existing `stats-pie.tsx` recharts error is unrelated, already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)