### PR TITLE
fix(resume): hide skill logos in print to match text-only PDF download

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -266,13 +266,15 @@
     gap: 3pt !important;
   }
 
-  /* Skill badges: transparent pills with black ink + black logos. */
+  /* Skill badges: transparent pills with black ink, no logos. Brand icons are
+     a web-only flourish — the printed/PDF resume stays clean text so it scans
+     well for recruiters and parses cleanly for ATS, matching the PDF download. */
   .skill-items span {
     background: transparent !important;
     padding: 1pt 6pt 1pt 0 !important;
   }
   .skill-items svg {
-    fill: #000 !important;
+    display: none !important;
   }
 
   /* Condense to ~2 pages: cap bullets per role (mirrors the PDF).


### PR DESCRIPTION
## What

In `@media print`, skill badge logos are now hidden (`display: none`) instead of being recolored black.

## Why

The resume has two independent export paths that disagreed on skills:

| Path | Skills rendering | Icons? |
|---|---|---|
| Web view | `SkillBadge` DOM components | ✅ brand logos |
| Native Print (Cmd+P) | same DOM + `@media print` | ✅ logos, black |
| Download button | separate `ResumePDF` via `@react-pdf/renderer` | ❌ plain text |

Native Print was the odd one out — it showed logos while the Download PDF emits `items.join(", ")`. This makes both *exported* artifacts clean text, which scans faster for recruiters and parses cleanly for ATS. Brand logos remain a web-only flourish.

## Decisions captured

- Skill badges stay **non-clickable** (no value linking a resume reader out to vendor docs).
- **Not** chasing more logos — simple-icons v16 can't supply AWS/Oracle/DynamoDB/Playwright; mixed logo/text pills are fine.

## Verification

- Web view: all 39 skill icons still render (`display: block`).
- Confirmed the compiled `@media print` stylesheet now folds `.skill-items svg` into the `display: none !important` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)