### PR TITLE
Tighten meta/OG descriptions and add subtle wordmark to social card

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -43,18 +43,36 @@ export default async function Image() {
           color: TEXT,
         }}
       >
-        {/* Eyebrow */}
+        {/* Top row: eyebrow + subtle wordmark (wayfinding, not a sales CTA) */}
         <div
           style={{
             display: "flex",
-            fontSize: 26,
-            fontWeight: 700,
-            letterSpacing: 6,
-            textTransform: "uppercase",
-            color: ACCENT,
+            alignItems: "center",
+            justifyContent: "space-between",
           }}
         >
-          Platform Engineering · DevEx · AI
+          <div
+            style={{
+              display: "flex",
+              fontSize: 26,
+              fontWeight: 700,
+              letterSpacing: 6,
+              textTransform: "uppercase",
+              color: ACCENT,
+            }}
+          >
+            Platform Engineering · DevEx · AI
+          </div>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 26,
+              fontWeight: 400,
+              color: MUTED,
+            }}
+          >
+            brignano.io ↗
+          </div>
         </div>
 
         {/* Name + tagline */}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,8 +15,14 @@ export interface SocialLink {
 export const SITE_NAME = "Anthony Brignano";
 export const SITE_TAGLINE = "I build the platforms thousands of engineers ship on";
 const SITE_TITLE = "Anthony Brignano — I build platforms engineers ship on";
+// Meta description: kept ~155 chars so Google doesn't truncate (it trims
+// around 150–160 in results).
 const SITE_DESCRIPTION =
-  "Internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes developer onboarding self-service and software delivery faster and safer.";
+  "I build internal developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling that makes software delivery faster and safer.";
+// Social previews show fewer characters than search results (~125 before they
+// truncate on mobile), so the OG/Twitter description is a tighter variant.
+const SITE_OG_DESCRIPTION =
+  "Developer platforms for 8,000+ engineers — CI/CD, DevOps intelligence, and AI-native tooling for faster, safer delivery.";
 
 export const siteMetadata: Metadata = {
   metadataBase: new URL("https://brignano.io"),
@@ -35,7 +41,7 @@ export const siteMetadata: Metadata = {
   // Next would ship a second, conflicting og:image tag.
   openGraph: {
     title: SITE_TITLE,
-    description: SITE_DESCRIPTION,
+    description: SITE_OG_DESCRIPTION,
     url: "https://brignano.io",
     siteName: SITE_NAME,
     locale: "en_US",
@@ -44,7 +50,7 @@ export const siteMetadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: SITE_TITLE,
-    description: SITE_DESCRIPTION,
+    description: SITE_OG_DESCRIPTION,
   },
   alternates: {
     canonical: "https://brignano.io",


### PR DESCRIPTION
## Summary

Follow-up to #182 (the PNG social card). A link-preview validator flagged three things on the now-live card; this PR resolves all three.

| Warning | Before | After |
| --- | --- | --- |
| Meta description too long (Google truncates ~150–160) | 186 chars | **156** |
| `og:description` too long (mobile previews truncate ~125) | 186 chars | **120** |
| Missing CTA in `og:image` | none | subtle **`brignano.io ↗`** wordmark |

## Changes

- **`lib/constants.ts`** — trim the meta `description` to 156 chars, and split off a tighter **`SITE_OG_DESCRIPTION`** (120 chars) for `openGraph`/`twitter`, since social cards truncate shorter than search results. Meta keeps the SEO keywords; the social variant stays punchy.
- **`app/opengraph-image.tsx`** — add a quiet `brignano.io ↗` wordmark to the top-right, balanced against the eyebrow. Deliberately a wayfinding/recall cue, **not** a hard sales CTA — the wrong register for a personal site shared peer-to-peer, where recognition matters more than click-through. (Verified the `↗` glyph exists in the Geist subset so satori renders it cleanly.)

## Verification

- `npm run build` (static export) succeeds.
- Built `out/index.html` confirms: `description` = 156, `og:description` = `twitter:description` = 120.
- Regenerated card renders correctly at 1200×630 with the wordmark in place.

https://claude.ai/code/session_011TX3BN3hVWRXoPz5zjdsJ6

---
_Generated by [Claude Code](https://claude.ai/code/session_011TX3BN3hVWRXoPz5zjdsJ6)_