### PR TITLE
Disambiguate hero subhead pronoun (they → engineers)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -61,7 +61,7 @@ export default function Home() {
               data-aos-delay={180}
               className="text-base sm:text-lg dark:text-zinc-400 text-zinc-600 mb-8 max-w-xl leading-relaxed"
             >
-              I build the shared tools and automation they rely on to ship software — faster, safer, and more consistently. Think of it as building the factory, not the products that roll off it. Increasingly, that means baking AI right into those tools.
+              I build the shared tools and automation engineers rely on to ship software — faster, safer, and more consistently. Think of it as building the factory, not the products that roll off it. Increasingly, that means baking AI right into those tools.
             </p>
 
             {/* Metric strip — proof above the fold. Dividers only once the row


### PR DESCRIPTION
Follow-up to #199.

In the hero, "they" could grammatically attach to **"platforms"** (the nearest plural noun):

> I build the platforms thousands of engineers ship on.
> I build the shared tools and automation **they** rely on to ship software…

Name the antecedent explicitly. Uses **"engineers"** (not "developers") to stay consistent with the rest of the site's wording — "8,000+ engineers," "thousands of engineers," etc.

One-word copy change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)