### PR TITLE
Fix Highlights cards stretching when a glossary pill is opened

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -202,7 +202,7 @@ export default function Home() {
 
           {/* Tier 1 — quantified outcomes with tappable skill pills that reveal
               a plain-language definition (components/highlight-card.tsx). */}
-          <div className="grid md:grid-cols-2 grid-cols-1 gap-4 auto-rows-fr">
+          <div className="grid md:grid-cols-2 grid-cols-1 gap-4 items-start">
             {achievements.map((achievement, index) => (
               <HighlightCard
                 key={index}

--- a/components/highlight-card.tsx
+++ b/components/highlight-card.tsx
@@ -25,7 +25,7 @@ export default function HighlightCard({
       data-aos="fade-up"
       data-aos-duration={600}
       data-aos-delay={index * 70}
-      className="bg-white/70 dark:bg-zinc-900/50 backdrop-blur-sm border dark:border-zinc-800 border-zinc-200 rounded-xl px-6 py-5 shadow-sm h-full flex flex-col"
+      className="bg-white/70 dark:bg-zinc-900/50 backdrop-blur-sm border dark:border-zinc-800 border-zinc-200 rounded-xl px-6 py-5 shadow-sm flex flex-col"
     >
       <p className="text-base font-semibold tracking-tight mb-2">
         {achievement.outcome}
@@ -34,7 +34,7 @@ export default function HighlightCard({
         {achievement.detail}
       </p>
 
-      <div className="flex flex-wrap gap-2 mt-auto">
+      <div className="flex flex-wrap gap-2">
         {achievement.skills.map((skill) => {
           const hasDefinition = Boolean(glossary[skill]);
 


### PR DESCRIPTION
Follow-up to #199.

## Bug
Opening a glossary-pill definition in one Highlights card stretched the **other card in its row** to the same height (empty gap, pills pushed to the bottom) — so it looked like every card expanded. Only visible at desktop width (2-column grid).

## Cause
The grid used `auto-rows-fr`, forcing equal-height rows; the card used `h-full` + `mt-auto` to fill and bottom-align. When one card grew, its row-mate stretched to match.

## Fix
- Grid: `auto-rows-fr` → `items-start` (each card sizes to its own content).
- Card: drop `h-full` and the pills' `mt-auto`.

Opening a definition now grows only the clicked card; the row-mate stays put.

Verified at 1280px: opening card 1's definition leaves card 2 at its natural height (no stretch). Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)