### PR TITLE
Fix resume experience cards jumping off-screen on mobile

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import yaml from "js-yaml";
 import type { ResumeData } from "@/types/resume";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
@@ -24,46 +24,24 @@ export default function Home() {
   const [resumeData, setResumeData] = useState<ResumeData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [expandedIndex, setExpandedIndex] = useState<number | null>(null);
-  const EXPERIENCE_ANIMATION_LOCK_MS = 360;
-  const experienceCardRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const scrollLockTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const [expandedIndices, setExpandedIndices] = useState<Set<number>>(
+    new Set()
+  );
 
-  const toggleExperience = (
-    index: number,
-    cardElement: HTMLDivElement,
-    event: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
-  ) => {
-    // Prevent any default scrolling behavior
-    if (event instanceof KeyboardEvent) {
-      event.preventDefault();
-    }
-
-    // Scroll the card into view only if it's not currently visible
-    const rect = cardElement.getBoundingClientRect();
-
-    // Only scroll if the card is out of view (above or below the viewport)
-    if (rect.top < 0 || rect.top > window.innerHeight) {
-      // Scroll with padding from the top so the header stays visible after expansion
-      const paddingFromTop = 80;
-      const scrollTop = window.scrollY + rect.top - paddingFromTop;
-      window.scrollTo(0, Math.max(0, scrollTop));
-    }
-
-    // Disable scrolling during animation
-    const originalOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    // Re-enable scrolling after animation completes
-    if (scrollLockTimeoutRef.current) {
-      clearTimeout(scrollLockTimeoutRef.current);
-    }
-    scrollLockTimeoutRef.current = setTimeout(() => {
-      document.body.style.overflow = originalOverflow;
-      scrollLockTimeoutRef.current = null;
-    }, EXPERIENCE_ANIMATION_LOCK_MS);
-
-    setExpandedIndex((prev) => (prev === index ? null : index));
+  // Each card toggles independently. Because nothing above a tapped card
+  // changes size, its position never shifts — no manual scroll or body-scroll
+  // lock is needed (those caused the card to fly off-screen on mobile when an
+  // accordion collapsed the taller card above it).
+  const toggleExperience = (index: number) => {
+    setExpandedIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
   };
 
   useEffect(() => {
@@ -92,25 +70,16 @@ export default function Home() {
     fetchResume();
   }, []);
 
+  // Expand the current ("present") role by default, once, after the data loads.
   useEffect(() => {
-    if (!resumeData || expandedIndex !== null) return;
+    if (!resumeData) return;
     const presentIndex = resumeData.experience?.findIndex(
       (job) => String(job.endDate).toLowerCase() === "present"
     );
     if (presentIndex !== undefined && presentIndex >= 0) {
-      setExpandedIndex(presentIndex);
+      setExpandedIndices((prev) => (prev.size > 0 ? prev : new Set([presentIndex])));
     }
-  }, [resumeData, expandedIndex]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      if (scrollLockTimeoutRef.current) {
-        clearTimeout(scrollLockTimeoutRef.current);
-      }
-      document.body.style.overflow = "";
-    };
-  }, []);
+  }, [resumeData]);
 
   if (loading) {
     return (
@@ -243,26 +212,22 @@ export default function Home() {
                 {experience.map((job, index) => (
                   <div key={index} className="relative">
                     <div
-                      className={`absolute left-4 top-8 -translate-x-1/2 h-3 w-3 rounded-full border-2 z-10 ${expandedIndex === index
+                      className={`absolute left-4 top-8 -translate-x-1/2 h-3 w-3 rounded-full border-2 z-10 ${expandedIndices.has(index)
                           ? "border-zinc-400 bg-secondary-color"
                           : "dark:border-zinc-400 border-zinc-400 dark:bg-zinc-900 bg-zinc-100"
                         }`}
                       data-print-hide
                     />
                     <div
-                      ref={(element) => {
-                        experienceCardRefs.current[index] = element;
-                      }}
-                      className={`ml-8 relative dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 rounded-lg ${expandedIndex === index ? "cursor-default" : "cursor-pointer"}`}
+                      className="ml-8 relative dark:bg-primary-bg bg-secondary-bg border dark:border-zinc-800 border-zinc-200 p-6 rounded-lg cursor-pointer"
                       role="button"
                       tabIndex={0}
-                      aria-expanded={expandedIndex === index}
-                      onClick={(event) =>
-                        toggleExperience(index, event.currentTarget, event)
-                      }
+                      aria-expanded={expandedIndices.has(index)}
+                      onClick={() => toggleExperience(index)}
                       onKeyDown={(event) => {
                         if (event.key === "Enter" || event.key === " ") {
-                          toggleExperience(index, event.currentTarget, event);
+                          event.preventDefault();
+                          toggleExperience(index);
                         }
                       }}
                     >
@@ -292,7 +257,7 @@ export default function Home() {
                         </time>
                       </div>
                       <div
-                        className={`exp-body transition-all duration-300 overflow-hidden ${expandedIndex === index
+                        className={`exp-body transition-all duration-300 overflow-hidden ${expandedIndices.has(index)
                           ? "max-h-[3000px] mt-4"
                           : "max-h-0"
                           }`}


### PR DESCRIPTION
## Bug
On mobile, tapping an experience card on `/resume` scrolled wildly and the tapped section ended up off-screen — "I can't even see the section I clicked."

## Root cause
The list was an **accordion** (opening one card auto-collapsed the open one). The current role auto-expands to a ~1900px-tall card on mobile; tapping a card *below* it collapsed that tall card **above** the tap, pulling ~1300px of height out from above the tapped card. Measured: the tapped card's viewport top went **281px → −1363px** (flew off the top). Compounding it, `toggleExperience` set `document.body.style.overflow = "hidden"` for 360ms and did a manual `window.scrollTo`, both of which fight mobile scroll handling.

## Fix
Each card now toggles **independently** (a `Set` of expanded indices), so nothing above a tapped card changes size and its position can't shift. This let me delete the manual `scrollTo`, the body-scroll lock, the animation-lock timeout, and the unused refs.

- Current role still expands by default (once, after data loads).
- Keyboard Enter/Space now correctly `preventDefault` — the old `event instanceof KeyboardEvent` check never matched a React SyntheticEvent.
- Behavior change: more than one role can be open at once (fine on a resume, and what removes the whole bug class).

## Verification
Reproduced the original failure, then confirmed the fix at 375px: tapping a collapsed card keeps its top at ~its tap position (**267 → 251px**, in view), it expands in place, the card above stays open, and `body.overflow` is untouched. Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)