### PR TITLE
Home open-source graph: show current year instead of trailing 12 months

### DIFF
--- a/components/home-contributions.tsx
+++ b/components/home-contributions.tsx
@@ -16,12 +16,13 @@ const CALENDAR_THEME = {
 };
 
 /**
- * Calm, restrained contribution preview for the homepage. Uses a **trailing
- * 12-month window** (`year="last"`) rather than the calendar year so the grid
- * ends on the most recent activity instead of trailing into empty future
- * months — keeps the section feeling current for bursty / mid-year activity.
- * Real data only; the year selector, legend, and color legend chrome live on
- * the full /coding calendar this funnels to.
+ * Calm, restrained contribution preview for the homepage. Uses the **current
+ * calendar year** (matching the full /coding calendar) rather than a trailing
+ * 12-month window: most public activity lands in the current year, so this puts
+ * the active months on the left where the overflow container shows them first,
+ * instead of leading with last year's empty months (work commits live on a
+ * private GitHub Enterprise that never reaches this public graph). Real data
+ * only; the year selector, legend, and color legend chrome live on /coding.
  */
 export default function HomeContributions({
   username = "brignano",
@@ -29,12 +30,16 @@ export default function HomeContributions({
   username?: string;
 }) {
   const [mounted, setMounted] = useState(false);
+  const [year, setYear] = useState<number | null>(null);
   const [colorScheme, setColorScheme] = useState<"light" | "dark">("light");
 
   useEffect(() => {
     /* eslint-disable react-hooks/set-state-in-effect --
        client-only mount gate + theme sync, same as github-calendar-client */
     setMounted(true);
+    // Resolve the year from the browser clock after mount so server and client
+    // markup match (the calendar is client-only via the mounted gate anyway).
+    setYear(new Date().getFullYear());
 
     const root = document.documentElement;
     setColorScheme(root.classList.contains("dark") ? "dark" : "light");
@@ -49,17 +54,17 @@ export default function HomeContributions({
   return (
     <div className="overflow-x-auto -mx-1 px-1 py-1">
       <div className="min-w-[320px]">
-        {mounted && (
+        {mounted && year !== null && (
           <GitHubCalendar
             username={username}
-            year="last"
+            year={year}
             colorScheme={colorScheme}
             theme={CALENDAR_THEME}
             blockSize={11}
             blockMargin={4}
             fontSize={12}
             showColorLegend={false}
-            labels={{ totalCount: "{{count}} contributions in the last year" }}
+            labels={{ totalCount: "{{count}} contributions in {{year}}" }}
           />
         )}
       </div>


### PR DESCRIPTION
## Problem
The homepage "Open-source activity" graph looked lackluster — a wall of blank cells. It used `year="last"` (trailing 12 months), so last year's *empty* months (Aug–Dec, when public commits were quiet because work lives on a private GitHub Enterprise) sat on the **left**. Since the grid overflows its container, the default scroll position showed those blanks while the recent active months were scrolled off-screen to the right.

## Fix
Switch to the **current calendar year** (matching the `/coding` calendar). Public activity is concentrated in the current year, so the active months (Jan–Jul) now lead the view instead of last year's empty tail. Label updates to "{{count}} contributions in {{year}}".

- Year is resolved from the browser clock after mount (behind the existing `mounted` gate) to avoid a hydration mismatch — same approach as `GitHubCalendarClient`.

## Before / After
- **Before:** grid opened on Aug–Dec (empty), "950 contributions in the last year".
- **After:** grid opens on Jan–Feb–Mar (dense violet activity), "947 contributions in 2026".

Verified at desktop width; lint + typecheck clean. (Tradeoff: future months trail off empty to the right, scrolled out of view; every January it briefly looks sparse — identical to how `/coding` already behaves.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)