### PR TITLE
feat(home): quantify onboarding OKR as proven hours-not-weeks capability

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -334,7 +334,7 @@ export default function Home() {
             </p>
             <ul className="space-y-3 mb-6">
               {[
-                "Leading a CEO-sponsored push to make setup self-service for new engineers — down from a 40+ day wait.",
+                "Leading a CEO-sponsored push to make new-engineer setup self-service — the platform already gets a fresh machine productive in hours, down from a 40+ day wait, as it rolls out team-wide.",
                 "One consistent set of tools — a command-line app, a desktop app, and editor add-ons — that 1,000+ engineers adopted in the first 90 days.",
                 "One command builds any project — and runs the same on your laptop, in the cloud, or on a remote machine. Nothing to set up per project.",
                 "Live insight into where engineers lose time: the platform watches its own tools, surfaces the biggest slow-downs, and posts a public health status page anyone can subscribe to.",


### PR DESCRIPTION
Reframes the CEO-sponsored onboarding bullet in the Current Role section.

**Before:** "…make setup self-service for new engineers — down from a 40+ day wait."

**After:** "…make new-engineer setup self-service — the platform already gets a fresh machine productive in hours, down from a 40+ day wait, as it rolls out team-wide."

## Why
The OKR targets day-one onboarding, but KT is still ongoing, so a "reduced to 1 day" claim would overstate an org-wide result. The tooling already makes hours-not-weeks setup possible (proven in practice on a fresh machine), so the copy states that proven capability plus the rollout-in-progress status — keeping the compelling 40-days→hours metric within the §5.7 integrity rules on Hartford claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)