### PR TITLE
feat(resume): onboarding parity with homepage + plus/minus card expander

### DIFF
--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { ChevronDownIcon } from "@heroicons/react/24/outline";
+import { MinusIcon, PlusIcon } from "@heroicons/react/24/outline";
 import yaml from "js-yaml";
 import type { ResumeData } from "@/types/resume";
 import BreadcrumbSchema from "@/components/breadcrumb-schema";
@@ -259,13 +259,19 @@ export default function Home() {
                           </time>
                           {/* Explicit expand/collapse affordance — a cursor
                               change alone was invisible on touch, so people did
-                              not realize these cards open. */}
+                              not realize these cards open. Plus/minus (not a
+                              chevron) so it does not read as a second copy of
+                              the up-chevron scroll-to-top button. */}
                           <span
                             aria-hidden="true"
                             data-print-hide
-                            className={`inline-flex items-center justify-center rounded-full border dark:border-zinc-700 border-zinc-300 dark:bg-zinc-900/40 bg-white/60 p-1.5 text-zinc-500 dark:text-zinc-400 transition-transform duration-300 ${expandedIndices.has(index) ? "rotate-180" : ""}`}
+                            className="inline-flex items-center justify-center rounded-full border dark:border-zinc-700 border-zinc-300 dark:bg-zinc-900/40 bg-white/60 p-1.5 text-zinc-500 dark:text-zinc-400"
                           >
-                            <ChevronDownIcon className="h-4 w-4" />
+                            {expandedIndices.has(index) ? (
+                              <MinusIcon className="h-4 w-4" />
+                            ) : (
+                              <PlusIcon className="h-4 w-4" />
+                            )}
                           </span>
                         </div>
                       </div>

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -17,7 +17,7 @@ experience:
     summary: |
       Technical Lead for The Hartford's enterprise developer platform and developer experience strategy — the single pane of glass serving 8,000+ engineers — owning the architecture and evolution of CI/CD, DevOps intelligence, internal developer tooling, and AI-native delivery patterns across thousands of repositories.
     highlights:
-      - Lead the strategy, design, and delivery of the internal developer platform serving 8,000+ engineers, on a CEO-sponsored initiative to make developer onboarding self-service, down from a 40+ day baseline
+      - Lead the strategy, design, and delivery of the internal developer platform serving 8,000+ engineers, including a CEO-sponsored initiative making developer onboarding self-service — the platform provisions a new machine to productive in hours, down from a 40+ day baseline, now rolling out org-wide
       - Shipped a unified developer surface across a custom CLI, desktop app, and IDE extensions, reaching 1,000+ active engineers in the first 90 days
       - Designed "one build command, any stack" — context-aware builds that run identically locally, in CI, or fully remote on virtual build agents, against a custom base-image registry
       - Architected a real-time DevOps intelligence layer — an event bus streaming pipeline plus CLI/IDE telemetry into AWS, DynamoDB, and Snowflake for ML analysis of developer pain points


### PR DESCRIPTION
## Changes

**1. Resume onboarding parity** ([public/resume.yml](public/resume.yml))
Brings the CEO-sponsored onboarding bullet to parity with the homepage's honest framing (shipped in #205):

> …including a CEO-sponsored initiative making developer onboarding self-service — the platform provisions a new machine to productive in hours, down from a 40+ day baseline, now rolling out org-wide

Previously the resume stated only the "40+ day baseline" (the before) with no after-state. This drives both the `/resume` page and the build-time PDF. Stays within the §5.7 integrity rules — proven capability + rollout-in-progress, not an overstated org-wide result.

**2. Plus/minus card expander** ([app/resume/page.tsx](app/resume/page.tsx))
The experience cards used an up-chevron in a rounded pill to signal expand/collapse. When expanded, it was a near-twin of the up-chevron scroll-to-top button (same shape, same rounded container, same right edge) — visually redundant. Swapped to a plus/minus icon: distinct from the nav chevron and a stronger accordion affordance. Removed the now-unused rotation transition.

## Verification
- `/resume` renders the updated bullet; collapsed cards show ＋, expanded show −; expand/collapse interaction confirmed working; no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)