### PR TITLE
content(resume): add LDP career coach role to leadership entry

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -175,7 +175,7 @@ export default function Home() {
               In practice, that means taking the slow, repetitive, mistake-prone parts of building software and making them automatic and safe — the behind-the-scenes plumbing most people never see but every engineer relies on. Increasingly, that means building AI directly into those everyday tools.
             </p>
             <p>
-              Beyond the platform, I lead our enterprise hackathons, mentor emerging leaders as a rotation manager in the company&apos;s Leadership Development Program, and serve on the Central Connecticut State University (CCSU) Computer Science Industry Advisory Board.
+              Beyond the platform, I lead our enterprise hackathons, mentor emerging leaders as a rotation manager and career coach in the company&apos;s Leadership Development Program, and serve on the Central Connecticut State University (CCSU) Computer Science Industry Advisory Board.
             </p>
             <p>
               Outside of work, you&apos;ll usually find me climbing rocks, snowboarding through the woods, or exploring new ideas.

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -125,8 +125,8 @@ leadership:
     role: Lead / Organizer
     description: Lead and organize The Hartford's enterprise hackathons.
   - organization: Leadership Development Program
-    role: Rotation Manager
-    description: Mentor emerging leaders as a rotation manager in the company's Leadership Development Program.
+    role: Rotation Manager & Career Coach
+    description: Mentor emerging leaders in the company's Tech & Operations Leadership Development Program — managing rotational assignments and coaching associates on long-term career growth.
   - organization: Central Connecticut State University — Computer Science Industry Advisory Board
     role: Member
     description: Serve on the CCSU Computer Science Industry Advisory Board.


### PR DESCRIPTION
Adds the new Tech & Operations LDP career coach role to the site.

## Changes

- `public/resume.yml` — the existing **Leadership Development Program** entry now reads `Rotation Manager & Career Coach`, with a description covering both the rotational assignments and the career coaching. This flows through to both the `/resume` Leadership & Community cards and the generated PDF, which render from the same YAML.
- `app/page.tsx` — home page "About Me" copy updated to match ("rotation manager and career coach").

## Why one card instead of two

Both roles sit inside the same program, and the Leadership & Community grid keys off `organization` — two adjacent cards both titled "Leadership Development Program" would read as duplicates. Folding the second role into the existing entry keeps the card count at three and still surfaces the new title.

The description intentionally omits the number of coachees, since that count is expected to change.

## Not changed

`docs/tsd-site-modernization.md` quotes the old About paragraph as part of the original design spec — left as a historical record.

---
_Generated by [Claude Code](https://claude.ai/code/session_017WzRF2iAaKGpXmCEGS2WvK)_