### PR TITLE
Expand hackathon and CCSU IAB leadership cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -286,6 +286,14 @@
   main .lead-grid {
     grid-template-columns: repeat(3, 1fr) !important;
   }
+  /* Drop the long web copy for the one-liner; the row of 3 has no room for it,
+     and the PDF (resume-pdf.tsx) prints the same short `description`. */
+  main .lead-detail {
+    display: none !important;
+  }
+  main .lead-summary {
+    display: block !important;
+  }
 
   /* Flatten card chrome (border / fill / radius / padding / indent) to clean text. */
   .bg-secondary-bg,

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -412,8 +412,18 @@ export default function Home() {
                 <p className="text-sm text-primary-color font-medium mb-2">
                   {item.role}
                 </p>
+                {/* Screen shows the long form; print swaps in the one-liner so
+                    the cards stay a single row (globals.css) and the PDF stays
+                    two pages (resume-pdf.tsx). */}
+                {item.details && (
+                  <p className="lead-detail text-sm dark:text-zinc-400 text-zinc-600">
+                    {item.details}
+                  </p>
+                )}
                 {item.description && (
-                  <p className="text-sm dark:text-zinc-400 text-zinc-600">
+                  <p
+                    className={`lead-summary text-sm dark:text-zinc-400 text-zinc-600 ${item.details ? "hidden" : ""}`}
+                  >
                     {item.description}
                   </p>
                 )}

--- a/public/resume.yml
+++ b/public/resume.yml
@@ -123,13 +123,15 @@ experience:
 leadership:
   - organization: Enterprise Hackathons
     role: Lead / Organizer
-    description: Lead and organize The Hartford's enterprise hackathons.
+    description: Lead and organize The Hartford's enterprise hackathons, drawing hundreds of engineers each year.
+    details: Lead and organize The Hartford's enterprise hackathons, drawing hundreds of engineers each year. Every event takes months of planning — authoring the challenges, standing up environments and starter tooling, setting scoring criteria and prepping judges, and running the logistics of space, food, and prizes.
   - organization: Leadership Development Program
     role: Rotation Manager & Career Coach
     description: Mentor emerging leaders in the company's Tech & Operations Leadership Development Program — managing rotational assignments and coaching associates on long-term career growth.
   - organization: Central Connecticut State University — Computer Science Industry Advisory Board
     role: Member
-    description: Serve on the CCSU Computer Science Industry Advisory Board.
+    description: Judge senior projects each semester and help shape the computer science curriculum.
+    details: Judge student senior projects every semester and work with faculty to refine the computer science curriculum, keeping coursework aligned with current industry practice and the tools graduates will use on the job.
 skills:
   - category: Languages
     items:

--- a/types/resume.ts
+++ b/types/resume.ts
@@ -12,7 +12,10 @@ export interface ResumeData {
 export interface LeadershipRole {
   organization: string;
   role: string;
+  /** One-liner. Goes everywhere, including the two-page PDF and browser print. */
   description?: string;
+  /** Long form for the web card only — print falls back to `description`. */
+  details?: string;
 }
 
 export interface PersonalInfo {


### PR DESCRIPTION
Two of the three Leadership & Community cards were a single flat sentence and left out the substance of the work.

**Enterprise Hackathons** now says the events draw hundreds of engineers each year, and that each one takes months of planning — authoring the challenges, standing up environments and starter tooling, setting scoring criteria and prepping judges, and running the logistics of space, food, and prizes.

**CCSU Computer Science Industry Advisory Board** now covers judging student senior projects every semester and working with faculty to refine the curriculum so coursework tracks current industry practice.

## The print constraint

Dropping the expanded copy straight into `description` broke both print surfaces: the downloadable PDF went from two pages to three (`resume-pdf.tsx` caps experience bullets specifically to hold two pages), and the three-across leadership row in browser print (`globals.css`) has no room for a paragraph per card.

So the copy is split by surface:

- `description` — the one-liner both print paths already budget for. Lightly enriched (the hackathon line now carries the attendance number).
- `details` — new optional field, long form, screen only. Falls back to `description` when absent, so the LDP entry is untouched.

The web card renders `details` and marks it `.lead-detail`; the `@media print` block hides it and reveals the `.lead-summary` one-liner.

## Verification

- `npm run lint` and `npm run build` clean.
- PDF page count checked against `main`: 2 pages before, 3 pages with the naive change, 2 pages after the split.
- Screenshotted `/resume` in both screen and print emulation — screen shows the full copy in balanced cards, print keeps the single row of three.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBxPm7ZmvU5kGpiYjpSrmR)_